### PR TITLE
When reading a resource, on 404 destroy the resource

### DIFF
--- a/internal/provider/resource_account.go
+++ b/internal/provider/resource_account.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/accounts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -153,6 +154,10 @@ func resourceAccountRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.Errorf("error calling read account: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading account: %s", apiErr.Message)
 	}
 	if arr == nil {

--- a/internal/provider/resource_auth_method.go
+++ b/internal/provider/resource_auth_method.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/authmethods"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -163,6 +164,10 @@ func resourceAuthMethodRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error calling read auth method: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading auth method: %s", apiErr.Message)
 	}
 	if amrr == nil {

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/groups"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -127,6 +128,10 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.Errorf("error calling read group: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading group: %s", apiErr.Message)
 	}
 	if g == nil {

--- a/internal/provider/resource_host.go
+++ b/internal/provider/resource_host.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/hosts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -142,6 +143,10 @@ func resourceHostRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.Errorf("error calling read host: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading host: %s", apiErr.Message)
 	}
 	if hrr == nil {

--- a/internal/provider/resource_host_catalog.go
+++ b/internal/provider/resource_host_catalog.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/hostcatalogs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -116,6 +117,10 @@ func resourceHostCatalogRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("error calling read host catalog: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading host catalog: %s", apiErr.Message)
 	}
 	if hcrr == nil {

--- a/internal/provider/resource_host_set.go
+++ b/internal/provider/resource_host_set.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/hostsets"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -151,6 +152,10 @@ func resourceHostsetRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.Errorf("error calling read host set: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading host set: %s", apiErr.Message)
 	}
 	if hsrr == nil {

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/roles"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -191,6 +192,10 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.Errorf("error calling read role: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading role: %s", apiErr.Message)
 	}
 	if trr == nil {

--- a/internal/provider/resource_scope.go
+++ b/internal/provider/resource_scope.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/scopes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -132,6 +133,10 @@ func resourceScopeRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.Errorf("error calling read scope: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading scope: %s", apiErr.Message)
 	}
 	if srr == nil {

--- a/internal/provider/resource_target.go
+++ b/internal/provider/resource_target.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/targets"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -178,6 +179,10 @@ func resourceTargetRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("error calling read target: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading target: %s", apiErr.Message)
 	}
 	if trr == nil {

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/boundary/api/users"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -93,6 +94,10 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.Errorf("error calling read user: %v", err)
 	}
 	if apiErr != nil {
+		if apiErr.Status == int32(http.StatusNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading user: %s", apiErr.Message)
 	}
 	if urr == nil {


### PR DESCRIPTION
This allows configuration to continue after a resource has been
destroyed outside of TF by deleting the resource from state instead of
erroring.