### PR TITLE
Dont allow password change via tf apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Next (Unreleased)
+## 1.0.0 (Unreleased)
+
+We are bumping the version of the boundary terraform provider to 1.0.0 and will release new versions of the provider at its own cadence instead of keeping it in lockstep with Boundary.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 1.0.0 (Unreleased)
 
-We are bumping the version of the boundary terraform provider to 1.0.0 and will release new versions of the provider at its own cadence instead of keeping it in lockstep with Boundary.
+We are bumping the version of the Boundary Terraform provider to v1.0.0 and will release new versions of the provider at its own cadence instead of keeping it in lockstep with Boundary.
 
 ### Bug Fixes
 
-* During `terraform apply`, do not update existing user account passwords when the password field is updated in tf file.
+* During `terraform apply`, do not update existing user account passwords when the password field is updated in the tf file.
   ([Issue](https://github.com/hashicorp/terraform-provider-boundary/issues/71))
   ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/70))
 
@@ -12,7 +12,7 @@ We are bumping the version of the boundary terraform provider to 1.0.0 and will 
 
 ### New and Improved
 
-Update to `Boundary API 0.0.3` and `Boundary 0.1.4` ([see boundary changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md#014-20210105))
+Update to the Boundary Go SDK v0.0.3
 
 ## 0.1.0 (October 14, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
+## Next (Unreleased)
+
+### Bug Fixes
+
+* During `terraform apply`, do not update existing user account passwords when the password field is updated in tf file.
+  ([Issue](https://github.com/hashicorp/terraform-provider-boundary/issues/71))
+  ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/70))
+
 ## 0.1.4 (January 14, 2021)
 
-Boundary 0.1.4 release ([see boundary changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md#014-20210105))
+### New and Improved
+
+Update to `Boundary API 0.0.3` and `Boundary 0.1.4` ([see boundary changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md#014-20210105))
 
 ## 0.1.0 (October 14, 2020)
 

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -47,7 +47,7 @@ resource "boundary_account" "jeff" {
 - **description** (String) The account description.
 - **login_name** (String) The login name for this account.
 - **name** (String) The account name. Defaults to the resource name.
-- **password** (String) The account password.
+- **password** (String) The account password. Only set on create, changes will not be reflected when updating account.
 
 ### Read-only
 


### PR DESCRIPTION
### What does this PR do

Removes update path for account passwords during `terraform apply`

This means if a user makes a change to the default password in their `.tf` file, it will be applied to future users created, previously created users will keep their password.

```
resource "boundary_account" "users_acct" {
  for_each       = var.users
  name           = each.key
  description    = "User account for the person named ${each.key}"
  type           = "password"
  login_name     = lower(each.key)
  password       = "password"   <--------------- I.E. user changes this
  auth_method_id = boundary_auth_method.password.id
}
```