### PR TITLE
Deprecate target host_set_ids and credential_library_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Next
+
+### Deprecations/Changes
+
+* Deprecate fields `host_set_ids` and `application_credential_library_ids` of the 
+  `target` resource. See boundary 0.5.0 [changelog](https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md#deprecationschanges) for more detail on the deprecation.
+  ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/134)).
+
 ## 1.0.4 (August 19, 2021)
 
 ### New and Improved

--- a/docs/resources/managed_group.md
+++ b/docs/resources/managed_group.md
@@ -18,11 +18,11 @@ The managed group resource allows you to configure a Boundary group.
 ### Required
 
 - **auth_method_id** (String) The resource ID for the auth method.
+- **filter** (String) Boolean expression to filter the workers for this managed group.
 
 ### Optional
 
 - **description** (String) The managed group description.
-- **filter** (String) Boolean expression to filter the workers for this managed group.
 - **name** (String) The managed group name. Defaults to the resource name.
 
 ### Read-Only

--- a/docs/resources/target.md
+++ b/docs/resources/target.md
@@ -85,10 +85,10 @@ resource "boundary_target" "foo" {
   description  = "Foo target"
   default_port = "22"
   scope_id     = boundary_scope.project.id
-  host_set_ids = [
+  host_source_ids = [
     boundary_host_set.foo.id
   ]
-  application_credential_library_ids = [
+  application_credential_source_ids = [
     boundary_credential_library_vault.foo.id
   ]
 }
@@ -104,10 +104,12 @@ resource "boundary_target" "foo" {
 
 ### Optional
 
-- **application_credential_library_ids** (Set of String) A list of application credential library ID's.
+- **application_credential_library_ids** (Set of String, Deprecated) A list of application credential library ID's.
+- **application_credential_source_ids** (Set of String) A list of application credential source ID's.
 - **default_port** (Number) The default port for this target.
 - **description** (String) The target description.
-- **host_set_ids** (Set of String) A list of host set ID's.
+- **host_set_ids** (Set of String, Deprecated) A list of host set ID's.
+- **host_source_ids** (Set of String) A list of host source ID's.
 - **name** (String) The target name. Defaults to the resource name.
 - **session_connection_limit** (Number)
 - **session_max_seconds** (Number)

--- a/docs/resources/target.md
+++ b/docs/resources/target.md
@@ -83,6 +83,7 @@ resource "boundary_host_set" "foo" {
 resource "boundary_target" "foo" {
   name         = "foo"
   description  = "Foo target"
+	type         = "tcp"
   default_port = "22"
   scope_id     = boundary_scope.project.id
   host_source_ids = [

--- a/examples/resources/boundary_target/resource.tf
+++ b/examples/resources/boundary_target/resource.tf
@@ -68,6 +68,7 @@ resource "boundary_host_set" "foo" {
 resource "boundary_target" "foo" {
   name         = "foo"
   description  = "Foo target"
+	type         = "tcp"
   default_port = "22"
   scope_id     = boundary_scope.project.id
   host_source_ids = [

--- a/examples/resources/boundary_target/resource.tf
+++ b/examples/resources/boundary_target/resource.tf
@@ -70,10 +70,10 @@ resource "boundary_target" "foo" {
   description  = "Foo target"
   default_port = "22"
   scope_id     = boundary_scope.project.id
-  host_set_ids = [
+  host_source_ids = [
     boundary_host_set.foo.id
   ]
-  application_credential_library_ids = [
+  application_credential_source_ids = [
     boundary_credential_library_vault.foo.id
   ]
 }

--- a/internal/provider/resource_managed_group.go
+++ b/internal/provider/resource_managed_group.go
@@ -51,7 +51,7 @@ func resourceManagedGroup() *schema.Resource {
 			managedGroupFilterKey: {
 				Description: "Boolean expression to filter the workers for this managed group.",
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do

- Adds support for new target fields `application_credential_source_ids` and `host_source_ids` 
- Deprecates `application_credential_library_ids` and `host_library_ids`