### PR TITLE
feat(role): Support partial success in role create/update

### DIFF
--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -167,24 +167,24 @@ func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	var diags diag.Diagnostics
 	if principalIds != nil {
 		tspr, err := rc.SetPrincipals(ctx, tcr.Item.Id, 0, principalIds, roles.WithAutomaticVersioning(true))
-		if err != nil {
+		switch {
+		case err != nil:
 			diags = append(diags, diag.Diagnostic{Severity: diag.Error, Summary: "error setting principals", Detail: err.Error()})
-		} else {
-			if tspr == nil {
-				return diag.Errorf("nil role after setting principal IDs")
-			}
+		case tspr == nil:
+			diags = append(diags, diag.Diagnostic{Severity: diag.Error, Summary: "nil role after setting principal IDs"})
+		default:
 			raw = tspr.GetResponse().Map
 		}
 	}
 
 	if grantStrings != nil {
 		tsgr, err := rc.SetGrants(ctx, tcr.Item.Id, 0, grantStrings, roles.WithAutomaticVersioning(true))
-		if err != nil {
+		switch {
+		case err != nil:
 			diags = append(diags, diag.Diagnostic{Severity: diag.Error, Summary: "error setting grants", Detail: err.Error()})
-		} else {
-			if tsgr == nil {
-				return diag.Errorf("nil role after setting grant strings")
-			}
+		case tsgr == nil:
+			diags = append(diags, diag.Diagnostic{Severity: diag.Error, Summary: "nil role after setting grant strings"})
+		default:
 			raw = tsgr.GetResponse().Map
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/boundary/issues/1752, I was going to transfer the issue to this repo but I have some questions of follow up work in Boundary that I will discuss with the team.

I also manually validated this as follows:
In a local tf file with a new role and `u_fakeuser` defined as principal:
```
resource "boundary_role" "role_with_bad_principal" {
  name     = "role_with_bad_principal"
  scope_id = boundary_scope.org.id
  grant_strings = [
    "id=*;type=auth-method;actions=list,authenticate",
    "type=scope;actions=list",
    "id={{account.id}};actions=read,change-password"
  ]
  principal_ids = ["u_fakeuser"]
}
```

And then running `terraform apply` leads to:
```
Error: error setting principals

  on main.tf line 93, in resource "boundary_role" "role_with_bad_principal":
  93: resource "boundary_role" "role_with_bad_principal" {

{"kind":"Internal", "message":"Unable to set principals on role:
iam.(Repository).SetPrincipalRoles: db.DoTx:
iam.(Repository).SetPrincipalRoles: unable to add users: db.CreateItems:
wt_user_id_check constraint failed: check constraint violated: integrity
violation: error #1000."}
```

After fixing the tf file principal to be a valid user and running `terraform apply` again, we get no errors.

Doing the same on main has the same first error, but running `terraform apply` has this error which is not recoverable but just fixing the tf file principal:

```
Error: error calling create role: {"kind":"InvalidArgument", "message":"Invalid request.  Request attempted to make second resource with the same field value that must be unique."}

  on main.tf line 93, in resource "boundary_role" "role_with_bad_principal":
  93: resource "boundary_role" "role_with_bad_principal" {
``` 
