### PR TITLE
Map Issuer and Subject from attributes elements

### DIFF
--- a/internal/provider/resource_account_oidc.go
+++ b/internal/provider/resource_account_oidc.go
@@ -70,9 +70,12 @@ func setFromAccountOidcResponseMap(d *schema.ResourceData, raw map[string]interf
 	d.Set(NameKey, raw["name"])
 	d.Set(DescriptionKey, raw["description"])
 	d.Set(AuthMethodIdKey, raw["auth_method_id"])
-	d.Set(accountOidcIssuerKey, raw["issuer"])
-	d.Set(accountOidcSubjectKey, raw["subject"])
 	d.SetId(raw["id"].(string))
+	if attrsVal, ok := raw["attributes"]; ok {
+		attrs := attrsVal.(map[string]interface{})
+		d.Set(accountOidcIssuerKey, attrs["issuer"])
+		d.Set(accountOidcSubjectKey, attrs["subject"])
+	}
 }
 
 func resourceAccountOidcCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
Fix the Issuer and Subject mapping from the API for an OIDC Account.
I hope it's not a too quick and dirty Fix, but it works for the latest Boundary version.

This Pull Request can solve the issue https://github.com/hashicorp/terraform-provider-boundary/issues/151