### PR TITLE
Add validate func for auth method type key

### DIFF
--- a/internal/provider/resource_auth_method.go
+++ b/internal/provider/resource_auth_method.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/boundary/api/authmethods"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAuthMethod() *schema.Resource {
@@ -46,10 +47,11 @@ func resourceAuthMethod() *schema.Resource {
 				ForceNew:    true,
 			},
 			TypeKey: {
-				Description: "The resource type.",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description:  "The resource type.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{authmethodTypePassword}, false),
 			},
 			authmethodMinLoginNameLengthKey: {
 				Description: "The minimum login name length.",

--- a/internal/provider/resource_auth_method.go
+++ b/internal/provider/resource_auth_method.go
@@ -47,11 +47,14 @@ func resourceAuthMethod() *schema.Resource {
 				ForceNew:    true,
 			},
 			TypeKey: {
-				Description:  "The resource type.",
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{authmethodTypePassword}, false),
+				Description: "The resource type.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				ValidateFunc: validation.StringInSlice([]string{
+					authmethodTypeOidc,
+					authmethodTypePassword,
+				}, false),
 			},
 			authmethodMinLoginNameLengthKey: {
 				Description: "The minimum login name length.",


### PR DESCRIPTION
## WHY

As of now (2022-02-26)、curretly the `password` or `oidc` type is supported. 
Thus, I added a validation func to check on validation.