### PR TITLE
Add missing required `type` argument to `boundary_host` and `boundary_host_set`

### DIFF
--- a/docs/resources/host.md
+++ b/docs/resources/host.md
@@ -40,6 +40,7 @@ resource "boundary_host" "example" {
   description     = "My first host!"
   address         = "10.0.0.1"
   host_catalog_id = boundary_host_catalog.static.id
+  type            = "static"
 }
 ```
 

--- a/docs/resources/host_set.md
+++ b/docs/resources/host_set.md
@@ -38,6 +38,7 @@ resource "boundary_host" "1" {
   address         = "10.0.0.1"
   host_catalog_id = boundary_host_catalog.static.id
   scope_id        = boundary_scope.project.id
+  type            = "static"
 }
 
 resource "boundary_host" "2" {
@@ -46,6 +47,7 @@ resource "boundary_host" "2" {
   address         = "10.0.0.2"
   host_catalog_id = boundary_host_catalog.static.id
   scope_id        = boundary_scope.project.id
+  type            = "static"
 }
 
 resource "boundary_host_set" "web" {


### PR DESCRIPTION
## WHY

This `type` argument is a required argument but missing from the examples.