### PR TITLE
Remove default_role from role

### DIFF
--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -126,7 +126,6 @@ resource "boundary_role" "readonly" {
 
 ### Optional
 
-- `default_role` (Boolean) Indicates that the role containing this value is the default role (that is, has the id 'r_default'), which triggers some specialized behavior to allow it to be imported and managed.
 - `description` (String) The role description.
 - `grant_scope_id` (String)
 - `grant_strings` (Set of String) A list of stringified grants for the role.

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -14,7 +14,6 @@ const (
 	roleGrantScopeIdKey = "grant_scope_id"
 	rolePrincipalIdsKey = "principal_ids"
 	roleGrantStringsKey = "grant_strings"
-	roleDefaultRoleKey  = "default_role"
 )
 
 func resourceRole() *schema.Resource {
@@ -68,11 +67,6 @@ func resourceRole() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			roleDefaultRoleKey: {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Indicates that the role containing this value is the default role (that is, has the id 'r_default'), which triggers some specialized behavior to allow it to be imported and managed.",
-			},
 		},
 	}
 }
@@ -101,11 +95,6 @@ func setFromRoleResponseMap(d *schema.ResourceData, raw map[string]interface{}) 
 }
 
 func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.Get(roleDefaultRoleKey).(bool) {
-		d.SetId("r_default")
-		return resourceRoleRead(ctx, d, meta)
-	}
-
 	md := meta.(*metaData)
 
 	var scopeId string
@@ -323,10 +312,6 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceRoleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.Get(roleDefaultRoleKey).(bool) {
-		return nil
-	}
-
 	md := meta.(*metaData)
 	rc := roles.NewClient(md.client)
 


### PR DESCRIPTION
Fixes #130 
The `default_role` was removed from Boundary pre-launch to avoid ambiguity on the meaning of `default`. The behavior was however never removed from the Terraform Provider. 

This is not being deprecated because it was never supported.