### PR TITLE
fix: set target credentials on update

### DIFF
--- a/internal/provider/resource_target.go
+++ b/internal/provider/resource_target.go
@@ -522,7 +522,7 @@ func resourceTargetUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			for _, credSourceId := range credSourceIds {
 				credentialSourceIds = append(credentialSourceIds, credSourceId.(string))
 			}
-			credOpts = append(credOpts, targets.WithApplicationCredentialSourceIds(credentialSourceIds))
+			credOpts = append(credOpts, targets.WithBrokeredCredentialSourceIds(credentialSourceIds))
 		}
 
 		if credentialSourceIdsVal, ok := d.GetOk(targetBrokeredCredentialSourceIdsKey); ok {
@@ -548,14 +548,16 @@ func resourceTargetUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			return diag.Errorf("error updating credential sources in target: %v", err)
 		}
 
-		if err := d.Set("application_credential_source_ids", result.Item.ApplicationCredentialSourceIds); err != nil {
-			return diag.FromErr(err)
+		if d.HasChange("application_credential_source_ids") || d.HasChange(targetBrokeredCredentialSourceIdsKey) {
+			if err := d.Set(targetBrokeredCredentialSourceIdsKey, result.Item.BrokeredCredentialSourceIds); err != nil {
+				return diag.FromErr(err)
+			}
 		}
-		if err := d.Set(targetBrokeredCredentialSourceIdsKey, result.Item.BrokeredCredentialSourceIds); err != nil {
-			return diag.FromErr(err)
-		}
-		if err := d.Set(targetInjectedAppCredentialSourceIdsKey, result.Item.InjectedApplicationCredentialSourceIds); err != nil {
-			return diag.FromErr(err)
+
+		if d.HasChange(targetInjectedAppCredentialSourceIdsKey) {
+			if err := d.Set(targetInjectedAppCredentialSourceIdsKey, result.Item.InjectedApplicationCredentialSourceIds); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
### Summary:

When updating a target with different credential sources, the credential types that had changed from the state file were applied. Since we are using the SetCredentialSources function, any credential ids that are stored in the state file, but have not changed would be lost.

### Fix:

Gather all the credential ids when performing a SetCredentialSource action.