### PR TITLE
fix: set secret variables to senitive

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -25,7 +25,7 @@ Deprecated: use `boundary_account_password` instead.
 - `description` (String) The account description.
 - `login_name` (String) The login name for this account.
 - `name` (String) The account name. Defaults to the resource name.
-- `password` (String) The account password. Only set on create, changes will not be reflected when updating account.
+- `password` (String, Sensitive) The account password. Only set on create, changes will not be reflected when updating account.
 
 ### Read-Only
 

--- a/docs/resources/account_password.md
+++ b/docs/resources/account_password.md
@@ -47,7 +47,7 @@ resource "boundary_account_password" "jeff" {
 - `description` (String) The account description.
 - `login_name` (String) The login name for this account.
 - `name` (String) The account name. Defaults to the resource name.
-- `password` (String) The account password. Only set on create, changes will not be reflected when updating account.
+- `password` (String, Sensitive) The account password. Only set on create, changes will not be reflected when updating account.
 
 ### Read-Only
 

--- a/docs/resources/auth_method_oidc.md
+++ b/docs/resources/auth_method_oidc.md
@@ -27,7 +27,7 @@ The OIDC auth method resource allows you to configure a Boundary auth_method_oid
 - `callback_url` (String) The URL that should be provided to the IdP for callbacks.
 - `claims_scopes` (List of String) Claims scopes.
 - `client_id` (String) The client ID assigned to this auth method from the provider.
-- `client_secret` (String) The secret key assigned to this auth method from the provider. Once set, only the hash will be kept and the original value can be removed from configuration.
+- `client_secret` (String, Sensitive) The secret key assigned to this auth method from the provider. Once set, only the hash will be kept and the original value can be removed from configuration.
 - `client_secret_hmac` (String) The HMAC of the client secret returned by the Boundary controller, which is used for comparison after initial setting of the value.
 - `description` (String) The auth method description.
 - `disable_discovered_config_validation` (Boolean) Disables validation logic ensuring that the OIDC provider's information from its discovery endpoint matches the information here. The validation is only performed at create or update time.

--- a/docs/resources/credential_ssh_private_key.md
+++ b/docs/resources/credential_ssh_private_key.md
@@ -50,14 +50,14 @@ resource "boundary_credential_ssh_private_key" "example" {
 ### Required
 
 - `credential_store_id` (String) ID of the credential store this credential belongs to.
-- `private_key` (String) The private key associated with the credential.
+- `private_key` (String, Sensitive) The private key associated with the credential.
 - `username` (String) The username associated with the credential.
 
 ### Optional
 
 - `description` (String) The description of the credential.
 - `name` (String) The name of the credential. Defaults to the resource name.
-- `private_key_passphrase` (String) The passphrase of the private key associated with the credential.
+- `private_key_passphrase` (String, Sensitive) The passphrase of the private key associated with the credential.
 
 ### Read-Only
 

--- a/docs/resources/credential_username_password.md
+++ b/docs/resources/credential_username_password.md
@@ -49,7 +49,7 @@ resource "boundary_credential_username_password" "example" {
 ### Required
 
 - `credential_store_id` (String) The credential store in which to save this username/password credential.
-- `password` (String) The password of this username/password credential.
+- `password` (String, Sensitive) The password of this username/password credential.
 - `username` (String) The username of this username/password credential.
 
 ### Optional

--- a/internal/provider/resource_account.go
+++ b/internal/provider/resource_account.go
@@ -60,7 +60,7 @@ func resourceAccount() *schema.Resource {
 				Description: "The account password. Only set on create, changes will not be reflected when updating account.",
 				Type:        schema.TypeString,
 				Optional:    true,
-
+				Sensitive:   true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if d.Id() == "" {
 						// This is a new resource do not suppress password diff

--- a/internal/provider/resource_account_password.go
+++ b/internal/provider/resource_account_password.go
@@ -65,7 +65,7 @@ func resourceAccountPassword() *schema.Resource {
 				Description: "The account password. Only set on create, changes will not be reflected when updating account.",
 				Type:        schema.TypeString,
 				Optional:    true,
-
+				Sensitive:   true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if d.Id() == "" {
 						// This is a new resource do not suppress password diff

--- a/internal/provider/resource_auth_method_oidc.go
+++ b/internal/provider/resource_auth_method_oidc.go
@@ -99,6 +99,7 @@ func resourceAuthMethodOidc() *schema.Resource {
 				Description: "The secret key assigned to this auth method from the provider. Once set, only the hash will be kept and the original value can be removed from configuration.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Sensitive:   true,
 			},
 			authmethodOidcIssuerKey: {
 				Description: "The issuer corresponding to the provider, which must match the issuer field in generated tokens.",

--- a/internal/provider/resource_credential_ssh_private_key.go
+++ b/internal/provider/resource_credential_ssh_private_key.go
@@ -62,6 +62,7 @@ func resourceCredentialSshPrivateKey() *schema.Resource {
 				Description: "The private key associated with the credential.",
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 			},
 			credentialSshPrivateKeyPrivateKeyHmacKey: {
 				Description: "The private key hmac.",
@@ -72,6 +73,7 @@ func resourceCredentialSshPrivateKey() *schema.Resource {
 				Description: "The passphrase of the private key associated with the credential.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Sensitive:   true,
 			},
 			credentialSshPrivateKeyPassphraseHmacKey: {
 				Description: "The private key passphrase hmac.",

--- a/internal/provider/resource_credential_username_password.go
+++ b/internal/provider/resource_credential_username_password.go
@@ -60,6 +60,7 @@ func resourceCredentialUsernamePassword() *schema.Resource {
 				Description: "The password of this username/password credential.",
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 			},
 			credentialUsernamePasswordPasswordHmacKey: {
 				Description: "The password hmac.",


### PR DESCRIPTION
### Summary:

Setting variables that are secrets to sensitive so they are not printed out to the terminal