### PR TITLE
fix: improve error message for invalid provider credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Canonical reference for changes, improvements, and bugfixes for the Boundary Ter
 * Add support for setting mapping overrides for vault credential libraries
   ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/287)).
 
+
+### Bug Fixes
+
+* Improve error message when authenticating to boundary.
+  ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/290)).
+
 ## 1.1.1 (October 12, 2022)
 
 ### Bug Fixes


### PR DESCRIPTION
### Summary:

When creating the boundary terraform provider:
```
provider "boundary" {
  addr                            = "http://127.0.0.1:9200"
  auth_method_id                  = "ampw_1234567890" 
  password_auth_method_login_name = "admin"          
  password_auth_method_password   = "password"       
}
```

When an error is returned from a failed authentication, we describe the raw api response. Example:
```
 Error: {"kind":"NotFound", "message":"Resource not found."}
│ 
│   with provider["registry.terraform.io/hashicorp/boundary"],
│   on main.tf line 10, in provider "boundary":
│   10: provider "boundary" {
```

This error is not really helpful and the true source of the issue is an invalid auth method id.

### Solution

Perform an api error casting check from the authentication request. On a 401 return an error describing that the login name or password are invalid. On a 404 return an error describing that the auth method id is invalid. Otherwise just return the error from the response.

### Examples:

Bad login name or password:
```
Error: invalid login name or password: {"kind":"Unauthenticated","message":"Unable to authenticate."}
│ 
│   with provider["localhost/providers/boundary"],
│   on main.tf line 10, in provider "boundary":
│   10: provider "boundary" {
```

Bad auth method id:
```
 Error: unknown auth_method_id: {"kind":"NotFound","message":"Resource not found."}
│ 
│   with provider["localhost/providers/boundary"],
│   on main.tf line 10, in provider "boundary":
│   10: provider "boundary" {
```

Bad url:
```
│ Error: error performing client request during Authenticate call: Post "http://127.0.0.1:9201/v1/auth-methods/ampw_1234567890:authenticate": EOF
│ 
│   with provider["localhost/providers/boundary"],
│   on main.tf line 10, in provider "boundary":
│   10: provider "boundary" {
```