### PR TITLE
chore: Remove copywrites from example files

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,16 @@
+schema_version = 1
+
+project {
+  license = "MPL-2.0"
+
+  copyright_year = 2020
+
+  # (OPTIONAL) A list of globs that should not have copyright or license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  # Default: []
+  header_ignore = [
+    "examples/**.tf",
+    "examples/**.sh",
+  ]
+}

--- a/docs/resources/worker.md
+++ b/docs/resources/worker.md
@@ -19,7 +19,7 @@ The resource allows you to create a self-managed worker object.
 
 - `description` (String) The description for the worker.
 - `name` (String) The name for the worker.
-- `scope_id` (String) The scope for the worker.  Defaults to `global`.
+- `scope_id` (String) The scope for the worker. Defaults to `global`.
 - `worker_generated_auth_token` (String) The worker authentication token required to register the worker for the worker-led authentication flow. Leaving this blank will result in a controller generated token.
 
 ### Read-Only

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 provider "boundary" {
   addr                            = "http://127.0.0.1:9200"
   auth_method_id                  = "ampw_1234567890" # changeme

--- a/examples/resources/boundary_account_password/import.sh
+++ b/examples/resources/boundary_account_password/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_account_password.foo <my-id>

--- a/examples/resources/boundary_account_password/resource.tf
+++ b/examples/resources/boundary_account_password/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_auth_method/import.sh
+++ b/examples/resources/boundary_auth_method/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_auth_method.foo <my-id>

--- a/examples/resources/boundary_auth_method/resource.tf
+++ b/examples/resources/boundary_auth_method/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_credential_json/import.sh
+++ b/examples/resources/boundary_credential_json/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_credential_json.example_json <my-id>

--- a/examples/resources/boundary_credential_json/resource.tf
+++ b/examples/resources/boundary_credential_json/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "global scope"

--- a/examples/resources/boundary_credential_library_vault/import.sh
+++ b/examples/resources/boundary_credential_library_vault/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_credential_library_vault.foo <my-id>

--- a/examples/resources/boundary_credential_library_vault/resource.tf
+++ b/examples/resources/boundary_credential_library_vault/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_credential_ssh_private_key/import.sh
+++ b/examples/resources/boundary_credential_ssh_private_key/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_credential_ssh_private_key.example_ssh_private_key <my-id>

--- a/examples/resources/boundary_credential_ssh_private_key/resource.tf
+++ b/examples/resources/boundary_credential_ssh_private_key/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "global scope"

--- a/examples/resources/boundary_credential_store_static/import.sh
+++ b/examples/resources/boundary_credential_store_static/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_credential_store_static.example_static_credential_store <my-id>

--- a/examples/resources/boundary_credential_store_static/resource.tf
+++ b/examples/resources/boundary_credential_store_static/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "global scope"

--- a/examples/resources/boundary_credential_store_vault/import.sh
+++ b/examples/resources/boundary_credential_store_vault/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_credential_store_vault.foo <my-id>

--- a/examples/resources/boundary_credential_store_vault/resource.tf
+++ b/examples/resources/boundary_credential_store_vault/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_credential_username_password/import.sh
+++ b/examples/resources/boundary_credential_username_password/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_credential_username_password.example_username_password <my-id>

--- a/examples/resources/boundary_credential_username_password/resource.tf
+++ b/examples/resources/boundary_credential_username_password/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "global scope"

--- a/examples/resources/boundary_group/import.sh
+++ b/examples/resources/boundary_group/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_group.foo <my-id>

--- a/examples/resources/boundary_group/project-specific/resource.tf
+++ b/examples/resources/boundary_group/project-specific/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_group/simple/resource.tf
+++ b/examples/resources/boundary_group/simple/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_host/import.sh
+++ b/examples/resources/boundary_host/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_host.foo <my-id>

--- a/examples/resources/boundary_host/resource.tf
+++ b/examples/resources/boundary_host/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_host_catalog/import.sh
+++ b/examples/resources/boundary_host_catalog/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_host_catalog.foo <my-id>

--- a/examples/resources/boundary_host_catalog/resource.tf
+++ b/examples/resources/boundary_host_catalog/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_host_catalog_plugin/import.sh
+++ b/examples/resources/boundary_host_catalog_plugin/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_host_catalog_plugin.foo <my-id>

--- a/examples/resources/boundary_host_catalog_plugin/resource.tf
+++ b/examples/resources/boundary_host_catalog_plugin/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_host_catalog_static/import.sh
+++ b/examples/resources/boundary_host_catalog_static/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_host_catalog_static.foo <my-id>

--- a/examples/resources/boundary_host_catalog_static/resource.tf
+++ b/examples/resources/boundary_host_catalog_static/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_host_set/import.sh
+++ b/examples/resources/boundary_host_set/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_host_set.foo <my-id>

--- a/examples/resources/boundary_host_set/resource.tf
+++ b/examples/resources/boundary_host_set/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_host_set_plugin/import.sh
+++ b/examples/resources/boundary_host_set_plugin/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_host_set_plugin.foo <my-id>

--- a/examples/resources/boundary_host_set_plugin/resource.tf
+++ b/examples/resources/boundary_host_set_plugin/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_host_set_static/import.sh
+++ b/examples/resources/boundary_host_set_static/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_host_set_static.foo <my-id>

--- a/examples/resources/boundary_host_set_static/resource.tf
+++ b/examples/resources/boundary_host_set_static/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_host_static/import.sh
+++ b/examples/resources/boundary_host_static/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_host_static.foo <my-id>

--- a/examples/resources/boundary_host_static/resource.tf
+++ b/examples/resources/boundary_host_static/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_role/import.sh
+++ b/examples/resources/boundary_role/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_role.foo <my-id>

--- a/examples/resources/boundary_role/project-specific/resource.tf
+++ b/examples/resources/boundary_role/project-specific/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_role/simple/resource.tf
+++ b/examples/resources/boundary_role/simple/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_role/user-grants/resource.tf
+++ b/examples/resources/boundary_role/user-grants/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_role/user/resource.tf
+++ b/examples/resources/boundary_role/user/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_scope/global.tf
+++ b/examples/resources/boundary_scope/global.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "global" {
   global_scope = true
   scope_id     = "global"

--- a/examples/resources/boundary_scope/import.sh
+++ b/examples/resources/boundary_scope/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_scope.foo <my-id>

--- a/examples/resources/boundary_scope/organization.tf
+++ b/examples/resources/boundary_scope/organization.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_scope/project.tf
+++ b/examples/resources/boundary_scope/project.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "project" {
   name                   = "project_one"
   description            = "My first scope!"

--- a/examples/resources/boundary_scope/role.tf
+++ b/examples/resources/boundary_scope/role.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name        = "organization_one"
   description = "My first scope!"

--- a/examples/resources/boundary_target/import.sh
+++ b/examples/resources/boundary_target/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_target.foo <my-id>

--- a/examples/resources/boundary_target/resource.tf
+++ b/examples/resources/boundary_target/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "global" {
   global_scope = true
   scope_id     = "global"

--- a/examples/resources/boundary_user/import.sh
+++ b/examples/resources/boundary_user/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_user.foo <my-id>

--- a/examples/resources/boundary_user/resource.tf
+++ b/examples/resources/boundary_user/resource.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_scope" "org" {
   name                     = "organization_one"
   description              = "My first scope!"

--- a/examples/resources/boundary_worker/import.sh
+++ b/examples/resources/boundary_worker/import.sh
@@ -1,4 +1,1 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 terraform import boundary_worker.foo <my-id>

--- a/examples/resources/boundary_worker/main.tf
+++ b/examples/resources/boundary_worker/main.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 resource "boundary_worker" "controller_led" {
   scope_id                    = "global"
   name                        = "worker 1"


### PR DESCRIPTION
These files are uses as input for generated doc files, as such they can
be ignored by `copywrite`.