### PR TITLE
refactor: reduce some repeated code in tests

### DIFF
--- a/internal/provider/resource_account_ldap_test.go
+++ b/internal/provider/resource_account_ldap_test.go
@@ -67,7 +67,7 @@ func TestAccLdapAccount(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckAccountResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckAccountResourceDestroy(t, provider, baseAccountType),
 		Steps: []resource.TestStep{
 			{
 				// create

--- a/internal/provider/resource_account_password_test.go
+++ b/internal/provider/resource_account_password_test.go
@@ -4,17 +4,12 @@
 package provider
 
 import (
-	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/hashicorp/boundary/api"
-	"github.com/hashicorp/boundary/api/accounts"
 	"github.com/hashicorp/boundary/testing/controller"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
@@ -69,7 +64,7 @@ func TestAccAccount(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckAccountPasswordResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckAccountResourceDestroy(t, provider, passwordAccountType),
 		Steps: []resource.TestStep{
 			{
 				// create
@@ -80,7 +75,7 @@ func TestAccAccount(t *testing.T) {
 					resource.TestCheckResourceAttr("boundary_account_password.foo", "type", "password"),
 					resource.TestCheckResourceAttr("boundary_account_password.foo", "login_name", "foo"),
 					resource.TestCheckResourceAttr("boundary_account_password.foo", "password", "foofoofoo"),
-					testAccCheckAccountPasswordResourceExists(provider, "boundary_account_password.foo"),
+					testAccCheckAccountResourceExists(provider, "boundary_account_password.foo"),
 				),
 			},
 			importStep("boundary_account_password.foo", "password"),
@@ -93,61 +88,10 @@ func TestAccAccount(t *testing.T) {
 					resource.TestCheckResourceAttr("boundary_account_password.foo", "type", "password"),
 					resource.TestCheckResourceAttr("boundary_account_password.foo", "login_name", "foo"),
 					resource.TestCheckResourceAttr("boundary_account_password.foo", "password", "foofoofoo"),
-					testAccCheckAccountPasswordResourceExists(provider, "boundary_account_password.foo"),
+					testAccCheckAccountResourceExists(provider, "boundary_account_password.foo"),
 				),
 			},
 			importStep("boundary_account_password.foo", "password"),
 		},
 	})
-}
-
-func testAccCheckAccountPasswordResourceExists(testProvider *schema.Provider, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		id := rs.Primary.ID
-		if id == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		md := testProvider.Meta().(*metaData)
-
-		amClient := accounts.NewClient(md.client)
-
-		if _, err := amClient.Read(context.Background(), id); err != nil {
-			return fmt.Errorf("Got an error when reading account %q: %v", id, err)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAccountPasswordResourceDestroy(t *testing.T, testProvider *schema.Provider) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if testProvider.Meta() == nil {
-			t.Fatal("got nil provider metadata")
-		}
-		md := testProvider.Meta().(*metaData)
-
-		for _, rs := range s.RootModule().Resources {
-			switch rs.Type {
-			case "boundary_account_password":
-				id := rs.Primary.ID
-
-				amClient := accounts.NewClient(md.client)
-
-				_, err := amClient.Read(context.Background(), id)
-				if apiErr := api.AsServerError(err); apiErr == nil || apiErr.Response().StatusCode() != http.StatusNotFound {
-					return fmt.Errorf("didn't get a 404 when reading destroyed account %q: %v", id, err)
-				}
-
-			default:
-				continue
-			}
-		}
-		return nil
-	}
 }

--- a/internal/provider/resource_account_test.go
+++ b/internal/provider/resource_account_test.go
@@ -69,7 +69,7 @@ func TestAccAccountBase(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckAccountResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckAccountResourceDestroy(t, provider, baseAccountType),
 		Steps: []resource.TestStep{
 			{
 				// create
@@ -125,7 +125,14 @@ func testAccCheckAccountResourceExists(testProvider *schema.Provider, name strin
 	}
 }
 
-func testAccCheckAccountResourceDestroy(t *testing.T, testProvider *schema.Provider) resource.TestCheckFunc {
+type accountType string
+
+const (
+	baseAccountType     accountType = "boundary_account"
+	passwordAccountType accountType = "boundary_account_password"
+)
+
+func testAccCheckAccountResourceDestroy(t *testing.T, testProvider *schema.Provider, typ accountType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if testProvider.Meta() == nil {
 			t.Fatal("got nil provider metadata")
@@ -134,7 +141,7 @@ func testAccCheckAccountResourceDestroy(t *testing.T, testProvider *schema.Provi
 
 		for _, rs := range s.RootModule().Resources {
 			switch rs.Type {
-			case "boundary_account":
+			case string(typ):
 				id := rs.Primary.ID
 
 				amClient := accounts.NewClient(md.client)

--- a/internal/provider/resource_auth_method_password_test.go
+++ b/internal/provider/resource_auth_method_password_test.go
@@ -4,17 +4,12 @@
 package provider
 
 import (
-	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/hashicorp/boundary/api"
-	"github.com/hashicorp/boundary/api/authmethods"
 	"github.com/hashicorp/boundary/testing/controller"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
@@ -50,7 +45,7 @@ func TestAccAuthMethodPassword(t *testing.T) {
 	var provider *schema.Provider
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckAuthMethodResourceDestroy(t, provider, ldapAuthMethodType),
+		CheckDestroy:      testAccCheckAuthMethodResourceDestroy(t, provider, passwordAuthMethodType),
 		Steps: []resource.TestStep{
 			{
 				// create
@@ -76,63 +71,4 @@ func TestAccAuthMethodPassword(t *testing.T) {
 			importStep("boundary_auth_method_password.foo"),
 		},
 	})
-}
-
-func testAccCheckAuthMethodResourceExists(testProvider *schema.Provider, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		id := rs.Primary.ID
-		if id == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		md := testProvider.Meta().(*metaData)
-
-		amClient := authmethods.NewClient(md.client)
-
-		if _, err := amClient.Read(context.Background(), id); err != nil {
-			return fmt.Errorf("Got an error when reading auth method %q: %w", id, err)
-		}
-
-		return nil
-	}
-}
-
-type authMethodType string
-
-const (
-	passwordAuthMethodType authMethodType = "boundary_auth_method_password"
-	ldapAuthMethodType     authMethodType = "boundary_auth_method_ldap"
-	oidcAuthMethodType     authMethodType = "boundary_auth_method_oidc"
-)
-
-func testAccCheckAuthMethodResourceDestroy(t *testing.T, testProvider *schema.Provider, typ authMethodType) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if testProvider.Meta() == nil {
-			t.Fatal("got nil provider metadata")
-		}
-		md := testProvider.Meta().(*metaData)
-
-		for _, rs := range s.RootModule().Resources {
-			switch rs.Type {
-			case string(typ):
-				id := rs.Primary.ID
-
-				amClient := authmethods.NewClient(md.client)
-
-				_, err := amClient.Read(context.Background(), id)
-				if apiErr := api.AsServerError(err); apiErr == nil || apiErr.Response().StatusCode() != http.StatusNotFound {
-					return fmt.Errorf("didn't get a 404 when reading destroyed auth method %q: %v", id, err)
-				}
-
-			default:
-				continue
-			}
-		}
-		return nil
-	}
 }

--- a/internal/provider/resource_auth_method_test.go
+++ b/internal/provider/resource_auth_method_test.go
@@ -52,7 +52,7 @@ func TestAccBaseAuthMethodPassword(t *testing.T) {
 	var provider *schema.Provider
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckAuthMethodResourceDestroy(t, provider, passwordAuthMethodType),
+		CheckDestroy:      testAccCheckAuthMethodResourceDestroy(t, provider, baseAuthMethodType),
 		Steps: []resource.TestStep{
 			{
 				// create
@@ -61,7 +61,7 @@ func TestAccBaseAuthMethodPassword(t *testing.T) {
 					resource.TestCheckResourceAttr("boundary_auth_method.foo", "description", fooBaseAuthMethodDesc),
 					resource.TestCheckResourceAttr("boundary_auth_method.foo", "name", "test"),
 					resource.TestCheckResourceAttr("boundary_auth_method.foo", "type", "password"),
-					testAccCheckBaseAuthMethodResourceExists(provider, "boundary_auth_method.foo"),
+					testAccCheckAuthMethodResourceExists(provider, "boundary_auth_method.foo"),
 				),
 			},
 			importStep("boundary_auth_method.foo"),
@@ -73,7 +73,7 @@ func TestAccBaseAuthMethodPassword(t *testing.T) {
 					resource.TestCheckResourceAttr("boundary_auth_method.foo", "description", fooBaseAuthMethodDescUpdate),
 					resource.TestCheckResourceAttr("boundary_auth_method.foo", "name", "test"),
 					resource.TestCheckResourceAttr("boundary_auth_method.foo", "type", "password"),
-					testAccCheckBaseAuthMethodResourceExists(provider, "boundary_auth_method.foo"),
+					testAccCheckAuthMethodResourceExists(provider, "boundary_auth_method.foo"),
 				),
 			},
 			importStep("boundary_auth_method.foo"),
@@ -81,7 +81,7 @@ func TestAccBaseAuthMethodPassword(t *testing.T) {
 	})
 }
 
-func testAccCheckBaseAuthMethodResourceExists(testProvider *schema.Provider, name string) resource.TestCheckFunc {
+func testAccCheckAuthMethodResourceExists(testProvider *schema.Provider, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -105,7 +105,16 @@ func testAccCheckBaseAuthMethodResourceExists(testProvider *schema.Provider, nam
 	}
 }
 
-func testAccCheckBaseAuthMethodResourceDestroy(t *testing.T, testProvider *schema.Provider) resource.TestCheckFunc {
+type authMethodType string
+
+const (
+	baseAuthMethodType     authMethodType = "boundary_auth_method"
+	passwordAuthMethodType authMethodType = "boundary_auth_method_password"
+	ldapAuthMethodType     authMethodType = "boundary_auth_method_ldap"
+	oidcAuthMethodType     authMethodType = "boundary_auth_method_oidc"
+)
+
+func testAccCheckAuthMethodResourceDestroy(t *testing.T, testProvider *schema.Provider, typ authMethodType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if testProvider.Meta() == nil {
 			t.Fatal("got nil provider metadata")
@@ -114,7 +123,7 @@ func testAccCheckBaseAuthMethodResourceDestroy(t *testing.T, testProvider *schem
 
 		for _, rs := range s.RootModule().Resources {
 			switch rs.Type {
-			case "boundary_auth_method":
+			case string(typ):
 				id := rs.Primary.ID
 
 				amClient := authmethods.NewClient(md.client)

--- a/internal/provider/resource_credential_library_vault_ssh_certificate_test.go
+++ b/internal/provider/resource_credential_library_vault_ssh_certificate_test.go
@@ -4,17 +4,14 @@
 package provider
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/boundary/api/credentiallibraries"
 	"github.com/hashicorp/boundary/testing/controller"
 	"github.com/hashicorp/boundary/testing/vault"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
@@ -144,7 +141,7 @@ func TestAccCredentialLibraryVaultSshCertificate(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultSshCertCredResc, credentialLibraryVaultPathKey, vaultSshCertCredLibPath),
 					resource.TestCheckResourceAttr(vaultSshCertCredResc, credentialLibraryVaultSshCertificateUsernameKey, vaultSshCertCredUsername),
 
-					testAccCheckCredentialLibraryVaultSshCertificateResourceExists(provider, vaultSshCertCredResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultSshCertCredResc),
 				),
 			},
 			importStep(vaultSshCertCredResc),
@@ -159,7 +156,7 @@ func TestAccCredentialLibraryVaultSshCertificate(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultSshCertCredResc, credentialLibraryVaultSshCertificateKeyTypeKey, vaultSshCertCredKeyType),
 					resource.TestCheckResourceAttr(vaultSshCertCredResc, credentialLibraryVaultSshCertificateKeyBitsKey, strconv.Itoa(vaultSshCertCredKeyBits)),
 
-					testAccCheckCredentialLibraryVaultSshCertificateResourceExists(provider, vaultSshCertCredResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultSshCertCredResc),
 				),
 			},
 			importStep(vaultSshCertCredResc),
@@ -172,7 +169,7 @@ func TestAccCredentialLibraryVaultSshCertificate(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultSshCertCredExtCOResc, credentialLibraryVaultPathKey, vaultSshCertCredLibPath),
 					resource.TestCheckResourceAttr(vaultSshCertCredExtCOResc, credentialLibraryVaultSshCertificateUsernameKey, vaultSshCertCredUsername),
 
-					testAccCheckCredentialLibraryVaultSshCertificateResourceExists(provider, vaultSshCertCredExtCOResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultSshCertCredExtCOResc),
 				),
 			},
 			importStep(vaultSshCertCredExtCOResc),
@@ -187,7 +184,7 @@ func TestAccCredentialLibraryVaultSshCertificate(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultSshCertCredExtCOResc, credentialLibraryVaultSshCertificateCriticalOptionsKey+".%", "0"),
 					resource.TestCheckResourceAttr(vaultSshCertCredExtCOResc, credentialLibraryVaultSshCertificateExtensionsKey+".%", "2"),
 
-					testAccCheckCredentialLibraryVaultSshCertificateResourceExists(provider, vaultSshCertCredExtCOResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultSshCertCredExtCOResc),
 				),
 			},
 			importStep(vaultSshCertCredExtCOResc),
@@ -202,31 +199,10 @@ func TestAccCredentialLibraryVaultSshCertificate(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultSshCertCredExtCOResc, credentialLibraryVaultSshCertificateCriticalOptionsKey+".%", "2"),
 					resource.TestCheckResourceAttr(vaultSshCertCredExtCOResc, credentialLibraryVaultSshCertificateExtensionsKey+".%", "1"),
 
-					testAccCheckCredentialLibraryVaultSshCertificateResourceExists(provider, vaultSshCertCredExtCOResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultSshCertCredExtCOResc),
 				),
 			},
 			importStep(vaultSshCertCredExtCOResc),
 		},
 	})
-}
-
-func testAccCheckCredentialLibraryVaultSshCertificateResourceExists(testProvider *schema.Provider, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		id := rs.Primary.ID
-		if id == "" {
-			return fmt.Errorf("no ID is set")
-		}
-		md := testProvider.Meta().(*metaData)
-		c := credentiallibraries.NewClient(md.client)
-		if _, err := c.Read(context.Background(), id); err != nil {
-			return fmt.Errorf("got an error reading %q: %w", id, err)
-		}
-
-		return nil
-	}
 }

--- a/internal/provider/resource_credential_library_vault_ssh_certificate_test.go
+++ b/internal/provider/resource_credential_library_vault_ssh_certificate_test.go
@@ -6,11 +6,9 @@ package provider
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/credentiallibraries"
 	"github.com/hashicorp/boundary/testing/controller"
 	"github.com/hashicorp/boundary/testing/vault"
@@ -39,7 +37,6 @@ resource "boundary_credential_library_vault_ssh_certificate" "example" {
   	path                = "%s"
   	username            = "%s"
 	key_type            = "ed25519"
-
 }`, vaultSshCertCredLibName,
 	vaultSshCertCredLibDesc,
 	vaultSshCertCredLibPath,
@@ -69,11 +66,9 @@ resource "boundary_credential_library_vault_ssh_certificate" "ext_co_example" {
   	path                = "%s"
   	username            = "%s"
 	key_type            = "ed25519"
-
 	extensions = {
 	  permit-pty = ""
     }
-
 	critical_options = {
 	  force-command = "/bin/foo"
 	}
@@ -90,7 +85,6 @@ resource "boundary_credential_library_vault_ssh_certificate" "ext_co_example" {
   	path                = "%s"
   	username            = "%s"
 	key_type            = "ed25519"
-
 	extensions = {
 	  permit-pty            = ""
 	  permit-X11-forwarding = ""
@@ -108,11 +102,9 @@ resource "boundary_credential_library_vault_ssh_certificate" "ext_co_example" {
   	path                = "%s"
   	username            = "%s"
 	key_type            = "ed25519"
-
 	extensions = {
 	  permit-pty = ""
     }
-
 	critical_options = {
 	  force-command  = "/bin/foo"
 	  source-address = "10.10.0.0/16"
@@ -141,7 +133,7 @@ func TestAccCredentialLibraryVaultSshCertificate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:        true,
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckCredentialLibraryVaultSshCertificateResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckCredentialLibraryVaultResourceDestroy(t, provider, sshCertVaultCredentialLibraryType),
 		Steps: []resource.TestStep{
 			{
 				// create
@@ -229,39 +221,12 @@ func testAccCheckCredentialLibraryVaultSshCertificateResourceExists(testProvider
 		if id == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		md := testProvider.Meta().(*metaData)
 		c := credentiallibraries.NewClient(md.client)
 		if _, err := c.Read(context.Background(), id); err != nil {
 			return fmt.Errorf("got an error reading %q: %w", id, err)
 		}
 
-		return nil
-	}
-}
-
-func testAccCheckCredentialLibraryVaultSshCertificateResourceDestroy(t *testing.T, testProvider *schema.Provider) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if testProvider.Meta() == nil {
-			t.Fatal("got nil provider metadata")
-		}
-		md := testProvider.Meta().(*metaData)
-
-		for _, rs := range s.RootModule().Resources {
-			switch rs.Type {
-			case "boundary_credential_library_vault":
-				id := rs.Primary.ID
-
-				c := credentiallibraries.NewClient(md.client)
-				_, err := c.Read(context.Background(), id)
-				if apiErr := api.AsServerError(err); apiErr == nil || apiErr.Response().StatusCode() != http.StatusNotFound {
-					return fmt.Errorf("didn't get a 404 when reading destroyed vault credential library %q: %v", id, err)
-				}
-
-			default:
-				continue
-			}
-		}
 		return nil
 	}
 }

--- a/internal/provider/resource_credential_library_vault_test.go
+++ b/internal/provider/resource_credential_library_vault_test.go
@@ -24,6 +24,7 @@ const (
 	vaultCredUsernamePasswordResc = "boundary_credential_library_vault.username_password_mapping_override"
 	vaultCredSshPrivateKeyResc    = "boundary_credential_library_vault.ssh_private_key_mapping_override"
 	vaultCredLibName              = "foo"
+	vaultCredLibNameOverride      = "base foo"
 	vaultCredLibDesc              = "the foo"
 	vaultCredLibPath              = "/foo/bar"
 	vaultCredLibMethodGet         = "GET"
@@ -83,7 +84,7 @@ resource "boundary_credential_library_vault" "username_password_mapping_override
 		password_attribute = "alternative_password_label"
 		username_attribute = "alternative_username_label"
 	}
-}`, vaultCredLibName,
+}`, vaultCredLibNameOverride,
 	vaultCredLibDesc,
 	vaultCredLibPath,
 	vaultCredLibMethodGet)
@@ -100,7 +101,7 @@ var vaultUsernamePasswordMappingOverrideCredLibResourceUpdate = fmt.Sprintf(`
 			password_attribute = "updated_password_label"
 			username_attribute = "updated_username_label"
 		}
-	}`, vaultCredLibName,
+	}`, vaultCredLibNameOverride,
 	vaultCredLibDesc,
 	vaultCredLibPath,
 	vaultCredLibMethodGet)
@@ -113,7 +114,7 @@ var vaultUsernamePasswordMappingOverrideCredLibResourceRemove = fmt.Sprintf(`
 		path                         = "%s"
 		http_method                  = "%s"
 		credential_type              = "username_password"
-	}`, vaultCredLibName,
+	}`, vaultCredLibNameOverride,
 	vaultCredLibDesc,
 	vaultCredLibPath,
 	vaultCredLibMethodGet)
@@ -167,7 +168,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultCredResc, credentialLibraryVaultHttpMethodKey, vaultCredLibMethodGet),
 					resource.TestCheckResourceAttr(vaultCredResc, credentialLibraryVaultHttpRequestBodyKey, ""),
 
-					testAccCheckCredentialLibraryVaultResourceExists(provider, vaultCredResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultCredResc),
 				),
 			},
 			importStep(vaultCredResc),
@@ -182,7 +183,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultCredResc, credentialLibraryVaultHttpMethodKey, vaultCredLibMethodPost),
 					resource.TestCheckResourceAttr(vaultCredResc, credentialLibraryVaultHttpRequestBodyKey, vaultCredLibRequestBody),
 
-					testAccCheckCredentialLibraryVaultResourceExists(provider, vaultCredResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultCredResc),
 				),
 			},
 			importStep(vaultCredResc),
@@ -198,7 +199,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultCredTypedResc, credentialLibraryVaultHttpRequestBodyKey, ""),
 					resource.TestCheckResourceAttr(vaultCredTypedResc, credentialLibraryCredentialTypeKey, "ssh_private_key"),
 
-					testAccCheckCredentialLibraryVaultResourceExists(provider, vaultCredTypedResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultCredTypedResc),
 				),
 			},
 			importStep(vaultCredResc),
@@ -206,7 +207,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 			{
 				Config: testConfig(url, fooOrg, firstProjectFoo, credStoreRes, vaultCredLibResourceUpdate, vaultUsernamePasswordMappingOverrideCredLibResource),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, NameKey, vaultCredLibName),
+					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, NameKey, vaultCredLibNameOverride),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, DescriptionKey, vaultCredLibDesc),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, credentialLibraryVaultPathKey, vaultCredLibPath),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, credentialLibraryVaultHttpMethodKey, vaultCredLibMethodGet),
@@ -215,7 +216,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, "credential_mapping_overrides.password_attribute", "alternative_password_label"),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, "credential_mapping_overrides.username_attribute", "alternative_username_label"),
 
-					testAccCheckCredentialLibraryVaultResourceExists(provider, vaultCredUsernamePasswordResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultCredUsernamePasswordResc),
 				),
 			},
 			importStep(vaultCredResc),
@@ -223,7 +224,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 			{
 				Config: testConfig(url, fooOrg, firstProjectFoo, credStoreRes, vaultCredLibResourceUpdate, vaultUsernamePasswordMappingOverrideCredLibResourceUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, NameKey, vaultCredLibName),
+					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, NameKey, vaultCredLibNameOverride),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, DescriptionKey, vaultCredLibDesc),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, credentialLibraryVaultPathKey, vaultCredLibPath),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, credentialLibraryVaultHttpMethodKey, vaultCredLibMethodGet),
@@ -232,7 +233,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, "credential_mapping_overrides.password_attribute", "updated_password_label"),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, "credential_mapping_overrides.username_attribute", "updated_username_label"),
 
-					testAccCheckCredentialLibraryVaultResourceExists(provider, vaultCredUsernamePasswordResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultCredUsernamePasswordResc),
 				),
 			},
 			importStep(vaultCredResc),
@@ -240,7 +241,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 			{
 				Config: testConfig(url, fooOrg, firstProjectFoo, credStoreRes, vaultCredLibResourceUpdate, vaultUsernamePasswordMappingOverrideCredLibResourceRemove),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, NameKey, vaultCredLibName),
+					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, NameKey, vaultCredLibNameOverride),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, DescriptionKey, vaultCredLibDesc),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, credentialLibraryVaultPathKey, vaultCredLibPath),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, credentialLibraryVaultHttpMethodKey, vaultCredLibMethodGet),
@@ -248,7 +249,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, credentialLibraryCredentialTypeKey, "username_password"),
 					resource.TestCheckResourceAttr(vaultCredUsernamePasswordResc, credentialLibraryCredentialMappingOverridesKey+".%", "0"),
 
-					testAccCheckCredentialLibraryVaultResourceExists(provider, vaultCredUsernamePasswordResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultCredUsernamePasswordResc),
 				),
 			},
 			importStep(vaultCredResc),
@@ -266,7 +267,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultCredSshPrivateKeyResc, "credential_mapping_overrides.private_key_passphrase_attribute", "alternative_passphrase_label"),
 					resource.TestCheckResourceAttr(vaultCredSshPrivateKeyResc, "credential_mapping_overrides.username_attribute", "alternative_username_label"),
 
-					testAccCheckCredentialLibraryVaultResourceExists(provider, vaultCredSshPrivateKeyResc),
+					testAccCheckCredentialLibraryResourceExists(provider, vaultCredSshPrivateKeyResc),
 				),
 			},
 			importStep(vaultCredResc),
@@ -274,7 +275,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 	})
 }
 
-func testAccCheckCredentialLibraryVaultResourceExists(testProvider *schema.Provider, name string) resource.TestCheckFunc {
+func testAccCheckCredentialLibraryResourceExists(testProvider *schema.Provider, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {

--- a/internal/provider/resource_credential_library_vault_test.go
+++ b/internal/provider/resource_credential_library_vault_test.go
@@ -155,7 +155,7 @@ func TestAccCredentialLibraryVault(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:        true,
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckCredentialLibraryVaultResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckCredentialLibraryVaultResourceDestroy(t, provider, baseVaultCredentialLibraryType),
 		Steps: []resource.TestStep{
 			{
 				// create
@@ -296,7 +296,14 @@ func testAccCheckCredentialLibraryVaultResourceExists(testProvider *schema.Provi
 	}
 }
 
-func testAccCheckCredentialLibraryVaultResourceDestroy(t *testing.T, testProvider *schema.Provider) resource.TestCheckFunc {
+type vaultCredentialLibraryType string
+
+const (
+	baseVaultCredentialLibraryType    vaultCredentialLibraryType = "boundary_credential_library_vault"
+	sshCertVaultCredentialLibraryType vaultCredentialLibraryType = "boundary_credential_library_vault_ssh_certificate"
+)
+
+func testAccCheckCredentialLibraryVaultResourceDestroy(t *testing.T, testProvider *schema.Provider, typ vaultCredentialLibraryType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if testProvider.Meta() == nil {
 			t.Fatal("got nil provider metadata")
@@ -305,7 +312,7 @@ func testAccCheckCredentialLibraryVaultResourceDestroy(t *testing.T, testProvide
 
 		for _, rs := range s.RootModule().Resources {
 			switch rs.Type {
-			case "boundary_credential_library_vault":
+			case string(typ):
 				id := rs.Primary.ID
 
 				c := credentiallibraries.NewClient(md.client)

--- a/internal/provider/resource_host_catalog_plugin_test.go
+++ b/internal/provider/resource_host_catalog_plugin_test.go
@@ -8,10 +8,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/hashicorp/boundary/api"
 	"github.com/hashicorp/boundary/api/hostcatalogs"
 	"github.com/hashicorp/boundary/testing/controller"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -156,7 +154,7 @@ func TestAccPluginHostCatalog(t *testing.T) {
 	var provider *schema.Provider
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckPluginHostCatalogResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckHostCatalogResourceDestroy(t, provider, baseHostCatalogType),
 		Steps: []resource.TestStep{
 			{
 				// test create
@@ -365,30 +363,6 @@ func testAccCheckPluginHostCatalogResourceExists(testProvider *schema.Provider, 
 		}
 
 		testStep++
-		return nil
-	}
-}
-
-func testAccCheckPluginHostCatalogResourceDestroy(t *testing.T, testProvider *schema.Provider) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		md := testProvider.Meta().(*metaData)
-
-		for _, rs := range s.RootModule().Resources {
-			switch rs.Type {
-			case "boundary_host_catalog":
-
-				id := rs.Primary.ID
-				hcClient := hostcatalogs.NewClient(md.client)
-
-				_, err := hcClient.Read(context.Background(), id)
-				if apiErr := api.AsServerError(err); apiErr == nil || apiErr.Response().StatusCode() != http.StatusNotFound {
-					return fmt.Errorf("didn't get a 404 when reading destroyed host catalog %q: %v", id, err)
-				}
-
-			default:
-				continue
-			}
-		}
 		return nil
 	}
 }

--- a/internal/provider/resource_host_catalog_static_test.go
+++ b/internal/provider/resource_host_catalog_static_test.go
@@ -70,7 +70,7 @@ func testAccHostCatalog(t *testing.T, static bool) {
 	var provider *schema.Provider
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckHostCatalogResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckHostCatalogResourceDestroy(t, provider, staticHostCatalogType),
 		Steps: []resource.TestStep{
 			{
 				// test create
@@ -119,13 +119,23 @@ func testAccCheckHostCatalogResourceExists(testProvider *schema.Provider, name s
 	}
 }
 
-func testAccCheckHostCatalogResourceDestroy(t *testing.T, testProvider *schema.Provider) resource.TestCheckFunc {
+type hostCatalogType string
+
+const (
+	baseHostCatalogType   hostCatalogType = "boundary_host_catalog"
+	staticHostCatalogType hostCatalogType = "boundary_host_catalog_static"
+)
+
+func testAccCheckHostCatalogResourceDestroy(t *testing.T, testProvider *schema.Provider, typ hostCatalogType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		if testProvider.Meta() == nil {
+			t.Fatal("got nil provider metadata")
+		}
 		md := testProvider.Meta().(*metaData)
 
 		for _, rs := range s.RootModule().Resources {
 			switch rs.Type {
-			case "boundary_host_catalog", "boundary_host_catalog_static":
+			case string(typ):
 
 				id := rs.Primary.ID
 				hcClient := hostcatalogs.NewClient(md.client)

--- a/internal/provider/resource_host_set_static_test.go
+++ b/internal/provider/resource_host_set_static_test.go
@@ -86,7 +86,7 @@ func testAccHostSetStatic(t *testing.T, static bool) {
 	var provider *schema.Provider
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckHostSetStaticResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckHostSetResourceDestroy(t, provider, baseHostSetType),
 		Steps: []resource.TestStep{
 			{
 				// test project hostset create
@@ -195,7 +195,11 @@ func testAccCheckHostSetStaticHostIDsSet(testProvider *schema.Provider, name str
 	}
 }
 
-func testAccCheckHostSetStaticResourceDestroy(t *testing.T, testProvider *schema.Provider) resource.TestCheckFunc {
+type hostSetType string
+
+const baseHostSetType hostSetType = "boundary_host_set"
+
+func testAccCheckHostSetResourceDestroy(t *testing.T, testProvider *schema.Provider, typ hostSetType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if testProvider.Meta() == nil {
 			t.Fatal("got nil provider metadata")
@@ -204,7 +208,7 @@ func testAccCheckHostSetStaticResourceDestroy(t *testing.T, testProvider *schema
 
 		for _, rs := range s.RootModule().Resources {
 			switch rs.Type {
-			case "boundary_host_set":
+			case string(typ):
 
 				id := rs.Primary.ID
 

--- a/internal/provider/resource_managed_group_ldap_test.go
+++ b/internal/provider/resource_managed_group_ldap_test.go
@@ -46,7 +46,7 @@ func TestAccManagedGroupLdap(t *testing.T) {
 	var provider *schema.Provider
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckManagedGroupResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckManagedGroupResourceDestroy(t, provider, ldapManagedGroupType),
 		Steps: []resource.TestStep{
 			{
 				// test create

--- a/internal/provider/resource_managed_group_test.go
+++ b/internal/provider/resource_managed_group_test.go
@@ -57,7 +57,7 @@ func TestAccManagedGroup(t *testing.T) {
 	var provider *schema.Provider
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories(&provider),
-		CheckDestroy:      testAccCheckManagedGroupResourceDestroy(t, provider),
+		CheckDestroy:      testAccCheckManagedGroupResourceDestroy(t, provider, baseManagedGroupType),
 		Steps: []resource.TestStep{
 			{
 				// test create
@@ -108,7 +108,14 @@ func testAccCheckManagedGroupResourceExists(testProvider *schema.Provider, name 
 	}
 }
 
-func testAccCheckManagedGroupResourceDestroy(t *testing.T, testProvider *schema.Provider) resource.TestCheckFunc {
+type managedGroupType string
+
+const (
+	baseManagedGroupType managedGroupType = "boundary_managed_group"
+	ldapManagedGroupType managedGroupType = "boundary_managed_group_ldap"
+)
+
+func testAccCheckManagedGroupResourceDestroy(t *testing.T, testProvider *schema.Provider, typ managedGroupType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if testProvider.Meta() == nil {
 			t.Fatal("got nil provider metadata")
@@ -118,7 +125,7 @@ func testAccCheckManagedGroupResourceDestroy(t *testing.T, testProvider *schema.
 
 		for _, rs := range s.RootModule().Resources {
 			switch rs.Type {
-			case "boundary_managed_group", "boundary_managed_group_ldap":
+			case string(typ):
 				grpClient := managedgroups.NewClient(md.client)
 				id := rs.Primary.ID
 


### PR DESCRIPTION
There was a decent amount of repeated code between similar test suites, consolidated them into a few more common tests. 

Also fixed a flaky test in `TestAccCredentialLibraryVault`