### PR TITLE
docs: Fix typo in Managed Group resource page

### DIFF
--- a/docs/resources/managed_group.md
+++ b/docs/resources/managed_group.md
@@ -18,7 +18,7 @@ The managed group resource allows you to configure a Boundary group.
 ### Required
 
 - `auth_method_id` (String) The resource ID for the auth method.
-- `filter` (String) Boolean expression to filter the workers for this managed group.
+- `filter` (String) Boolean expression to filter the users for this managed group.
 
 ### Optional
 
@@ -28,5 +28,3 @@ The managed group resource allows you to configure a Boundary group.
 ### Read-Only
 
 - `id` (String) The ID of the group.
-
-


### PR DESCRIPTION
From a [Slack conversation](https://hashicorp.slack.com/archives/C016ZKNM05T/p1679436965102879), the description for the `boundary_managed_group` resource mistakenly says that the filter is a Boolean expression to filter **workers**. It actually filters **users**. This pull request fixes the typo.