### PR TITLE
fix(credlib): Force new resource on credential_type change

### DIFF
--- a/internal/provider/resource_credential_library_vault.go
+++ b/internal/provider/resource_credential_library_vault.go
@@ -79,9 +79,10 @@ func resourceCredentialLibraryVault() *schema.Resource {
 				Required:    true,
 			},
 			credentialLibraryCredentialTypeKey: {
-				Description: "The type of credential the library generates.",
+				Description: "The type of credential the library generates. Cannot be updated on an existing resource.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 			},
 			credentialLibraryCredentialMappingOverridesKey: {
 				Description: "The credential mapping override.",


### PR DESCRIPTION
Fixes a bug where if the `credential_type` in a `boundary_credential_library_vault` resource is changed, TF will register the change and report that the resource was updated but doesn't actually change `credential_type`.

This is because `credential_type` is immutable in Boundary and we don't take it into account when updating a `boundary_credential_library_vault` resource, so this isn't actually valid operation.

I wasn't able to write tests for this, but I was able to manually validate it