### PR TITLE
feature: Add support for using ldap primary auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,19 @@ Canonical reference for changes, improvements, and bugfixes for the Boundary Ter
 * Add support for using default auth method if no auth method ID is provided for provider
   ([PR])(https://github.com/hashicorp/terraform-provider-boundary/pull/385))
 * Add support for using ldap primary auth method
-  ([PR])(https://github.com/hashicorp/terraform-provider-boundary/pull/392))  
+  ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/392))  
 
 ### Bug Fixes
 
 * Allow users to set OIDC maxAge value to 0 to require immediate reauth
   ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/364))
+
+### Deprecations/Changes
+
+* Deprecate `password_auth_method_login_name` & `password_auth_method_password` for Terraform Provider.
+  `password_auth_method_login_name` & `password_auth_method_password` fields have been set to deprecated 
+  with a recommendation to use `auth_method_login_name` & `auth_method_password` fields instead.
+  ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/392))
 
 ## 1.1.4 (February 15, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Canonical reference for changes, improvements, and bugfixes for the Boundary Ter
   ([PR])(https://github.com/hashicorp/terraform-provider-boundary/pull/379))
 * Add support for using default auth method if no auth method ID is provided for provider
   ([PR])(https://github.com/hashicorp/terraform-provider-boundary/pull/385))
+* Add support for using ldap primary auth method
+  ([PR])(https://github.com/hashicorp/terraform-provider-boundary/pull/392))  
 
 ### Bug Fixes
 

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/hashicorp/terraform-provider-boundary
 go 1.20
 
 require (
-	github.com/hashicorp/boundary v0.10.1-0.20230421143835-bc47a60f2f43
+	github.com/hashicorp/boundary v0.10.1-0.20230503134529-a2f8d87bfbdf
 	github.com/hashicorp/boundary/api v0.0.36
 	github.com/hashicorp/boundary/sdk v0.0.32
 	github.com/hashicorp/cap v0.2.0
+	github.com/hashicorp/cap/ldap v0.0.0-20230123181313-9c0fb924b0d9
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-kms-wrapping/v2 v2.0.9-0.20230316234854-f5e78cca83a8
 	github.com/hashicorp/go-secure-stdlib/configutil/v2 v2.0.7
@@ -14,7 +15,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.3
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
-	github.com/jimlambrt/gldap v0.1.4
+	github.com/jimlambrt/gldap v0.1.6
 	github.com/kr/pretty v0.3.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.8.2
@@ -65,12 +66,11 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.2 // indirect
-	github.com/hashicorp/cap/ldap v0.0.0-20230123181313-9c0fb924b0d9 // indirect
 	github.com/hashicorp/dbassert v0.0.0-20210708202608-ecf920cf1ed8 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/eventlogger v0.1.2-0.20230227112545-f26a3bdf6871 // indirect
 	github.com/hashicorp/eventlogger/filters/encrypt v0.1.8-0.20230227112545-f26a3bdf6871 // indirect
-	github.com/hashicorp/go-bexpr v0.1.10 // indirect
+	github.com/hashicorp/go-bexpr v0.1.12 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-dbw v0.0.0-20220910135738-ed4505749995 // indirect
@@ -172,7 +172,7 @@ require (
 	github.com/zalando/go-keyring v0.2.1 // indirect
 	github.com/zclconf/go-cty v1.13.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
+	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -646,8 +646,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.2 h1:BqHID5W5qnMkug0Z8UmL8tN0gAy4jQ+B4WFt8cCgluU=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.2/go.mod h1:ZbS3MZTZq/apAfAEHGoB5HbsQQstoqP92SjAqtQ9zeg=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
-github.com/hashicorp/boundary v0.10.1-0.20230421143835-bc47a60f2f43 h1:XUNkijJirW56aXanofon5bfPx+Gn51ljTfjgW+VgrPA=
-github.com/hashicorp/boundary v0.10.1-0.20230421143835-bc47a60f2f43/go.mod h1:Hc5N/3M/ISpEBeIaP/4pLB7C/HWADjLim63/6ZgGOgY=
+github.com/hashicorp/boundary v0.10.1-0.20230503134529-a2f8d87bfbdf h1:J0YH7wCUfbw6qCphbCKlgoxXHq6hVLla9fye9INOQXo=
+github.com/hashicorp/boundary v0.10.1-0.20230503134529-a2f8d87bfbdf/go.mod h1:h47rH5a7mDm9InP7qHKfH73DAAHAqvAa+SbFeXHsXuc=
 github.com/hashicorp/boundary/api v0.0.36 h1:Xi/QFJcovRgEgPKiFSamfgMS+dPxpY/yYxy0JqQNo44=
 github.com/hashicorp/boundary/api v0.0.36/go.mod h1:vvX0DoPuyA2HCq3juZb1/IwJrLuQJQMG1bZaQ7fvRMY=
 github.com/hashicorp/boundary/sdk v0.0.32 h1:YY6WUbphq47BUotl75fwPpdG8CqoyblNVD4Mmh9X1lY=
@@ -666,8 +666,8 @@ github.com/hashicorp/eventlogger v0.1.2-0.20230227112545-f26a3bdf6871 h1:F5Q9e2z
 github.com/hashicorp/eventlogger v0.1.2-0.20230227112545-f26a3bdf6871/go.mod h1://CHt6/j+Q2lc0NlUB5af4aS2M0c0aVBg9/JfcpAyhM=
 github.com/hashicorp/eventlogger/filters/encrypt v0.1.8-0.20230227112545-f26a3bdf6871 h1:PETLEST31DMXHOibJLl/nvcc5Tz4mo6eaXdCxT+lebQ=
 github.com/hashicorp/eventlogger/filters/encrypt v0.1.8-0.20230227112545-f26a3bdf6871/go.mod h1:EQPLoX6CONA9BSYUovTQBHfPGE91g7wOxv03sO29FzY=
-github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
-github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
+github.com/hashicorp/go-bexpr v0.1.12 h1:XrdVhmwu+9iYxIUWxsGVG7NQwrhzJZ0vR6nbN5bLgrA=
+github.com/hashicorp/go-bexpr v0.1.12/go.mod h1:ACktpcSySkFNpcxWSClFrut7wicd9WzisnvHuw+g9K8=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -887,8 +887,8 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jhump/protoreflect v1.9.1-0.20210817181203-db1a327a393e h1:Yb4fEGk+GtBSNuvy5rs0ZJt/jtopc/z9azQaj3xbies=
-github.com/jimlambrt/gldap v0.1.4 h1:PoB5u4ND0E+6W99JtQJvcjGFw+iKi3Gx3M60oOJBOqE=
-github.com/jimlambrt/gldap v0.1.4/go.mod h1:ia/l4Jhm+tdupLvZe7tRCbpv+HyXr1B5QFirsewfWEA=
+github.com/jimlambrt/gldap v0.1.6 h1:fnpRGhuHxWjavhDvEjwwveneNrQZuoEfOoDxKWYmtF8=
+github.com/jimlambrt/gldap v0.1.6/go.mod h1:BRdefIDhx2uYBjxL0fRBGi3eyOvAkkRIXSJYMCyzCaI=
 github.com/jinzhu/gorm v1.9.12 h1:Drgk1clyWT9t9ERbzHza6Mj/8FY/CqMyVzOiHviMo6Q=
 github.com/jinzhu/gorm v1.9.12/go.mod h1:vhTjlKSJUTWNtcbQtrMBFCxy7eXTzeCAzfL5fBZT/Qs=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -1038,7 +1038,6 @@ github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
-github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/mitchellh/pointerstructure v1.2.1 h1:ZhBBeX8tSlRpu/FFhXH4RC4OJzFlqsQhoHZAz4x7TIw=
 github.com/mitchellh/pointerstructure v1.2.1/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
@@ -1426,8 +1425,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 h1:5llv2sWeaMSnA3w2kS57ouQQ4pudlXrR0dCgw51QK9o=
+golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jimlambrt/gldap"
 	"github.com/jimlambrt/gldap/testdirectory"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -313,26 +312,9 @@ func createDefaultLdap(t *testing.T) *testdirectory.Directory {
 
 	groups := []*gldap.Entry{
 		testdirectory.NewGroup(t, "admin", []string{"alice"}),
-		testdirectory.NewGroup(t, "admin", []string{"eve"}, testdirectory.WithDefaults(t, &testdirectory.Defaults{UPNDomain: "example.com"})),
 	}
 
-	tokenGroups := map[string][]*gldap.Entry{
-		"S-1-1": {
-			testdirectory.NewGroup(t, "admin-token-group", []string{"alice"}),
-		},
-	}
-
-	sidBytes, err := ldap.SIDBytes(1, 1)
-	require.NoError(t, err)
-	users := testdirectory.NewUsers(t, []string{"alice", "bob"}, testdirectory.WithMembersOf(t, "admin"), testdirectory.WithTokenGroups(t, sidBytes))
-	users = append(
-		users,
-		testdirectory.NewUsers(
-			t,
-			[]string{"eve"},
-			testdirectory.WithDefaults(t, &testdirectory.Defaults{UPNDomain: "example.com"}),
-			testdirectory.WithMembersOf(t, "admin"))...,
-	)
+	users := testdirectory.NewUsers(t, []string{"alice"}, testdirectory.WithMembersOf(t, "admin"))
 
 	for _, u := range users {
 		u.Attributes = append(u.Attributes,
@@ -344,7 +326,6 @@ func createDefaultLdap(t *testing.T) *testdirectory.Directory {
 
 	td.SetUsers(users...)
 	td.SetGroups(groups...)
-	td.SetTokenGroups(tokenGroups)
 
 	return td
 }

--- a/internal/provider/resource_account_ldap_test.go
+++ b/internal/provider/resource_account_ldap_test.go
@@ -56,6 +56,29 @@ resource "boundary_account_ldap" "foo" {
 	login_name     = "foo"
 	auth_method_id = boundary_auth_method_ldap.foo.id
 }`, testAccountLdapNameUpdate, testAccountLdapDescUpdate)
+
+	testProviderLdapAccountConfig = `
+resource "boundary_account_ldap" "test-ldap" {
+	name           = "alice"
+	description    = "test"
+	type           = "ldap"
+	login_name     = "%s"
+	auth_method_id = boundary_auth_method_ldap.test-ldap.id
+}
+
+resource "boundary_user" "alice" {
+	name        = "alice"
+	description = "test user resource"
+	account_ids = [boundary_account_ldap.test-ldap.id]
+	scope_id = boundary_scope.global.id
+}
+
+resource "boundary_role" "ldap_principal" {
+	scope_id = boundary_scope.global.id
+	grant_scope_id = boundary_scope.global.id
+	grant_strings = ["id=*;type=*;actions=*"]
+	principal_ids = [boundary_user.alice.id]
+}`
 )
 
 func TestAccLdapAccount(t *testing.T) {

--- a/internal/provider/resource_auth_method_ldap_test.go
+++ b/internal/provider/resource_auth_method_ldap_test.go
@@ -73,6 +73,20 @@ EOT
   ]
 }`
 
+	testPrimaryAuthMethodLdap = `
+resource "boundary_auth_method_ldap" "test-ldap" {
+	name        		 = "test"
+	description 		 = "test auth method ldap"
+	scope_id    		 = "global"
+	is_primary_for_scope = true
+  	urls         	  	 = ["ldap://%s:%d"]
+	user_dn           	 = "%s"
+	group_dn          	 = "%s"
+	discover_dn 	  	 = true
+	enable_groups    	 = true
+	insecure_tls	 	 = true
+}`
+
 	testAuthMethodLdapUpdate = `
 resource "boundary_auth_method_ldap" "test-ldap" {
 	name                 = "test"


### PR DESCRIPTION
- Enable LDAP authentication through TF Provider
- Enable easier LDAP authentication by automatically setting the `auth_method_id` for the Terraform provider if LDAP is the primary auth method or only auth method.
- Combine fields for auth_method `login_name` & `password`
- Bump up `github.com/jimlambrt/gldap` & `github.com/hashicorp/boundary` to pull in needed changes for TF changes

### Using the Primary Auth Method(LDAP) in Global Scope
```
provider "boundary" {
  addr                            = "http://127.0.0.1:9200"
  auth_method_login_name = "myuser"
  auth_method_password   = "passpass"
}
```

### Using the Primary Auth Method(LDAP) in a passed-in scope:
```
provider "boundary" {
  addr                            = "http://127.0.0.1:9200"
  auth_method_login_name = "myuser"
  auth_method_password   = "passpass"
  scope_id                        = "s_1234567890"
}
```

### Using auth_method_id (traditional)
```
provider "boundary" {
  addr                            = "http://127.0.0.1:9200"
  auth_method_id                  = "ampw_1234567890"
  auth_method_login_name = "myuser"
  auth_method_password   = "passpass"
}
```

### Considerations
`password` & `LDAP` auth methods both need a `login_name` & `password` for Terraform Provider. 
Instead of having separate Terraform `password_auth_method_*` & `ldap_auth_method_*` fields that take the same information, a new `auth_method_login_name`& `auth_method_password` has been added to pass in data required by both auth methods. 
`password_auth_method_login_name` & `password_auth_method_password` fields have been set to deprecated with a recommendation to use `auth_method_login_name`& `auth_method_password` fields instead.

