### PR TITLE
chore: Deprecate type field for boundary_account_password

### DIFF
--- a/examples/resources/boundary_account_password/resource.tf
+++ b/examples/resources/boundary_account_password/resource.tf
@@ -13,7 +13,6 @@ resource "boundary_auth_method" "password" {
 
 resource "boundary_account_password" "jeff" {
   auth_method_id = boundary_auth_method.password.id
-  type           = "password"
   login_name     = "jeff"
   password       = "$uper$ecure"
 }

--- a/internal/provider/resource_account_password.go
+++ b/internal/provider/resource_account_password.go
@@ -56,7 +56,7 @@ func resourceAccountPassword() *schema.Resource {
 			TypeKey: {
 				Description: "The resource type.",
 				Type:        schema.TypeString,
-				Deprecated:  "The value for this field will be infered since there is only one possible value.",
+				Deprecated:  "The value for this field will be infered since 'password' is the only possible value.",
 				Default:     accountTypePassword,
 				Optional:    true,
 				ForceNew:    true,

--- a/internal/provider/resource_account_password.go
+++ b/internal/provider/resource_account_password.go
@@ -56,7 +56,9 @@ func resourceAccountPassword() *schema.Resource {
 			TypeKey: {
 				Description: "The resource type.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Deprecated:  "The value for this field will be infered since there is only one possible value.",
+				Default:     accountTypePassword,
+				Optional:    true,
 				ForceNew:    true,
 			},
 			accountLoginNameKey: {


### PR DESCRIPTION
The `boundary_account_password` resource in the boundary provider has a required `type` field but the only valid value is "password." Deprecating the `type` field and setting a default value. Users will still be able to pass in a value for the `type` field. This will prevent existing configs from breaking.

 Example: The missing `type` field will default to `password`.
 
 ```
resource "boundary_account_password" "jeff" {
  auth_method_id = boundary_auth_method.password.id
  login_name     = "jeff"
  password       = "$uper$ecure"
}
 ```