### PR TITLE
chore: deprecate type field for boundary_account_ldap

### DIFF
--- a/internal/provider/resource_account_ldap.go
+++ b/internal/provider/resource_account_ldap.go
@@ -54,7 +54,9 @@ func resourceAccountLdap() *schema.Resource {
 			TypeKey: {
 				Description: "The resource type.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Deprecated:  "The value for this field will be infered since 'ldap' is the only possible value.",
+				Default:     accountTypeLdap,
+				Optional:    true,
 				ForceNew:    true,
 			},
 			accountLoginNameKey: {


### PR DESCRIPTION
The `boundary_account_ldap` resource in the boundary provider has a required `type` field but the only valid value is "ldap". Deprecating the `type` field and setting a default value of `ldap`. 

Users will still be able to pass in a value for the `type` field. This will prevent existing configs from breaking.

 Example: The missing `type` field will default to `ldap`.
 
 ```
resource "boundary_account_ldap" "foo" {
	name           = "test name"
	description    = "test description"
	login_name     = "foo"
	auth_method_id = boundary_auth_method_ldap.foo.id
}
 ```