### PR TITLE
fix: default auth method with recovery kms

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -156,9 +156,10 @@ func providerAuthenticate(ctx context.Context, d *schema.ResourceData, md *metaD
 		md.client.SetToken(token.(string))
 	}
 
-	// If auth_method_id is not set, get the default auth method ID for the given scope ID
+	// If auth_method_id is not set, get the default auth method ID for the given scope ID.
+	// Skip fetching default auth method when recovery_kms_hcl is set or the client token isn't null.
 	authMethodId, authMethodIdOk := d.GetOk("auth_method_id")
-	if !authMethodIdOk {
+	if !authMethodIdOk && !recoveryKmsHclOk && md.client.Token() == "" {
 		defaultAuthMethodId, err := getDefaultAuthMethodId(ctx, amClient, providerScope, "")
 		if err != nil {
 			return err

--- a/internal/provider/resource_auth_method_oidc_test.go
+++ b/internal/provider/resource_auth_method_oidc_test.go
@@ -50,7 +50,7 @@ var (
 resource "boundary_auth_method_oidc" "foo" {
 	name        = "test"
 	description = "%s"
-	scope_id    = boundary_scope.org1.id
+	scope_id    = "global"
 	depends_on  = [boundary_role.org1_admin]
 
   issuer            = "%s"
@@ -73,7 +73,7 @@ EOT
 resource "boundary_auth_method_oidc" "foo" {
 	name                 = "test"
 	description          = "%s"
-	scope_id             = boundary_scope.org1.id
+	scope_id             = "global"
 	is_primary_for_scope = true
 	depends_on           = [boundary_role.org1_admin]
 


### PR DESCRIPTION
- Add test coverage for authenticating with recovery kms mechanism & an auth method that is not a `password` auth-method
- Skip fetching default auth method when `recovery_kms_hcl` is set or the client token isn't null

### Considerations
- Set `boundary_auth_method_oidc.foo` test resource's scope to "global" to easily allow testing the default auth method
- Removed `auth_method_id`, `password_auth_method_login_name` & `password_auth_method_password` from `testConfigWithRecovery` since those fields are not needed for authenticating with [Recovery KMS](https://developer.hashicorp.com/boundary/docs/oss/installing/no-gen-resources#recovery-kms-workflow). Using those fields also previously caused tests to pass with the bug.

This should cover test coverage for the bug raised: https://github.com/hashicorp/terraform-provider-boundary/issues/404