### PR TITLE
docs: update host set plugin filters examples

### DIFF
--- a/docs/resources/host_set_plugin.md
+++ b/docs/resources/host_set_plugin.md
@@ -51,7 +51,7 @@ resource "boundary_host_catalog_plugin" "aws_example" {
 resource "boundary_host_set_plugin" "web" {
   name            = "My web host set plugin"
   host_catalog_id = boundary_host_catalog_plugin.aws_example.id
-  attributes_json = jsonencode({ "filters" = "tag:service-type=web" })
+  attributes_json = jsonencode({ "filters" = ["tag:service-type=web"] })
 }
 
 resource "boundary_host_set_plugin" "foobar" {
@@ -59,8 +59,7 @@ resource "boundary_host_set_plugin" "foobar" {
   host_catalog_id     = boundary_host_catalog_plugin.aws_example.id
   preferred_endpoints = ["cidr:54.0.0.0/8"]
   attributes_json = jsonencode({
-    "filters" = "tag-key=foo",
-    "filters" = "tag-key=bar"
+    "filters" = ["tag-key=foo", "tag-key=bar"]
   })
 }
 
@@ -69,8 +68,7 @@ resource "boundary_host_set_plugin" "launch" {
   host_catalog_id       = boundary_host_catalog_plugin.aws_example.id
   sync_interval_seconds = 60
   attributes_json = jsonencode({
-    "filters" = "tag:development=prod,dev",
-    "filters" = "launch-time=2022-01-04T*"
+    "filters" = ["tag:development=prod,dev", "launch-time=2022-01-04T*"]
   })
 }
 

--- a/examples/resources/boundary_host_set_plugin/resource.tf
+++ b/examples/resources/boundary_host_set_plugin/resource.tf
@@ -36,7 +36,7 @@ resource "boundary_host_catalog_plugin" "aws_example" {
 resource "boundary_host_set_plugin" "web" {
   name            = "My web host set plugin"
   host_catalog_id = boundary_host_catalog_plugin.aws_example.id
-  attributes_json = jsonencode({ "filters" = "tag:service-type=web" })
+  attributes_json = jsonencode({ "filters" = ["tag:service-type=web"] })
 }
 
 resource "boundary_host_set_plugin" "foobar" {
@@ -44,8 +44,7 @@ resource "boundary_host_set_plugin" "foobar" {
   host_catalog_id     = boundary_host_catalog_plugin.aws_example.id
   preferred_endpoints = ["cidr:54.0.0.0/8"]
   attributes_json = jsonencode({
-    "filters" = "tag-key=foo",
-    "filters" = "tag-key=bar"
+    "filters" = ["tag-key=foo", "tag-key=bar"]
   })
 }
 
@@ -54,8 +53,7 @@ resource "boundary_host_set_plugin" "launch" {
   host_catalog_id       = boundary_host_catalog_plugin.aws_example.id
   sync_interval_seconds = 60
   attributes_json = jsonencode({
-    "filters" = "tag:development=prod,dev",
-    "filters" = "launch-time=2022-01-04T*"
+    "filters" = ["tag:development=prod,dev", "launch-time=2022-01-04T*"]
   })
 }
 


### PR DESCRIPTION
This change is to update the example docs for `host_set_plugin` filters attribute to use a list strings instead of just strings.

WIthout using a list of strings, Terraform will falsely detect diffs with host set plugin`filters`.

AWS host set plugin expects filters attributes to be passed as a list of strings instead of strings. It is currently backwards compatible with strings due to the migration [normalizeData func](https://github.com/hashicorp/boundary-plugin-aws/blob/7bf9fe2ecf1f20d7ff8aea8306909abcde1d17a4/plugin/service/host/plugin.go#L256) on AWS host plugin.

Previously this was not working onCreate but [Boundary PR-3338](https://github.com/hashicorp/boundary/pull/3338) fixed the bug.