### PR TITLE
feat: add target resource session recording support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Canonical reference for changes, improvements, and bugfixes for the Boundary Ter
 
 * Add support for a storage bucket as a resource
   ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/417))
+* Add option to enable session recording on a target resource
+  ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/421))  
 
 ## 1.1.8 (June 13, 2023)
 

--- a/docs/resources/target.md
+++ b/docs/resources/target.md
@@ -168,14 +168,14 @@ resource "boundary_target" "address_foo" {
 - `default_port` (Number) The default port for this target.
 - `description` (String) The target description.
 - `egress_worker_filter` (String) Boolean expression to filter the workers used to access this target
-- `enable_session_recording` (Boolean) HCP/Ent Only. Enable sessions recording for this target
+- `enable_session_recording` (Boolean) HCP/Ent Only. Enable sessions recording for this target. Only applicable for SSH targets.
 - `host_source_ids` (Set of String) A list of host source ID's. Cannot be used alongside address.
 - `ingress_worker_filter` (String) HCP Only. Boolean expression to filter the workers a user will connect to when initiating a session against this target
 - `injected_application_credential_source_ids` (Set of String) A list of injected application credential source ID's.
 - `name` (String) The target name. Defaults to the resource name.
 - `session_connection_limit` (Number)
 - `session_max_seconds` (Number)
-- `storage_bucket_id` (String) HCP/Ent Only. Storage bucket for this target
+- `storage_bucket_id` (String) HCP/Ent Only. Storage bucket for this target. Only applicable for SSH targets.
 - `worker_filter` (String, Deprecated) Boolean expression to filter the workers for this target
 
 ### Read-Only

--- a/examples/resources/boundary_target/resource.tf
+++ b/examples/resources/boundary_target/resource.tf
@@ -69,6 +69,20 @@ resource "boundary_host_set" "foo" {
   ]
 }
 
+resource "boundary_storage_bucket" "aws_example" {
+  name            = "My aws storage bucket"
+  description     = "My first storage bucket!"
+  scope_id        = boundary_scope.org.id
+  plugin_name     = "aws"
+  bucket_name     = "mybucket"
+  attributes_json = jsonencode({ "region" = "us-east-1" })
+  secrets_json = jsonencode({
+    "access_key_id"     = "aws_access_key_id_value",
+    "secret_access_key" = "aws_secret_access_key_value"
+  })
+  worker_filter = "\"pki\" in \"/tags/type\""
+}
+
 resource "boundary_target" "foo" {
   name         = "foo"
   description  = "Foo target"
@@ -95,6 +109,22 @@ resource "boundary_target" "ssh_foo" {
   injected_application_credential_source_ids = [
     boundary_credential_library_vault.foo.id
   ]
+}
+
+resource "boundary_target" "ssh_session_recording_foo" {
+  name         = "ssh_foo"
+  description  = "Ssh target"
+  type         = "ssh"
+  default_port = "22"
+  scope_id     = boundary_scope.project.id
+  host_source_ids = [
+    boundary_host_set.foo.id
+  ]
+  injected_application_credential_source_ids = [
+    boundary_credential_library_vault.foo.id
+  ]
+  enable_session_recording = true
+  storage_bucket_id        = boundary_storage_bucket.aws_example
 }
 
 resource "boundary_target" "address_foo" {

--- a/internal/provider/resource_target.go
+++ b/internal/provider/resource_target.go
@@ -136,12 +136,12 @@ func resourceTarget() *schema.Resource {
 				ConflictsWith: []string{targetHostSourceIdsKey},
 			},
 			targetEnableSessionRecordingKey: {
-				Description: "HCP/Ent Only. Enable sessions recording for this target",
+				Description: "HCP/Ent Only. Enable sessions recording for this target. Only applicable for SSH targets.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
 			targetStorageBucketIdKey: {
-				Description: "HCP/Ent Only. Storage bucket for this target",
+				Description: "HCP/Ent Only. Storage bucket for this target. Only applicable for SSH targets.",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},


### PR DESCRIPTION
- add new optional `enable_session_recording` field for enabling or disabling session recording
- add new optional `storage_bucket_id` field for setting the storage bucket for the target
- These new fields are applicable to Boundary HCP/ENT

### Considerations
- There is no test coverage yet until we add support for testing enterprise-only features. Manually tested the changes