### PR TITLE
fix: Append correct storage bucket worker filter option

### DIFF
--- a/internal/provider/resource_storage_bucket.go
+++ b/internal/provider/resource_storage_bucket.go
@@ -449,7 +449,7 @@ func resourceStorageBucketUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if d.HasChange(WorkerFilterKey) {
-		opts = append(opts, storagebuckets.DefaultBucketName())
+		opts = append(opts, storagebuckets.DefaultWorkerFilter())
 		workerFilterVal, ok := d.GetOk(WorkerFilterKey)
 		if ok {
 			workerFilterStr := workerFilterVal.(string)


### PR DESCRIPTION
During terraform `storage_bucket` resource update, the default worker filter option used is the `DefaultBucketName` instead of `DefaultWorkerFilter`. Update it to use the correct option