### PR TITLE
Correct `boundary_worker` resource example

### DIFF
--- a/docs/resources/worker.md
+++ b/docs/resources/worker.md
@@ -19,7 +19,7 @@ resource "boundary_worker" "controller_led" {
   description = "self managed worker with controller led auth"
 }
 
-resource "boundary_self_managed_worker" "worker_led" {
+resource "boundary_worker" "worker_led" {
   scope_id                    = "global"
   name                        = "worker 2"
   description                 = "self managed worker with worker led auth"

--- a/examples/resources/boundary_worker/resource.tf
+++ b/examples/resources/boundary_worker/resource.tf
@@ -4,7 +4,7 @@ resource "boundary_worker" "controller_led" {
   description = "self managed worker with controller led auth"
 }
 
-resource "boundary_self_managed_worker" "worker_led" {
+resource "boundary_worker" "worker_led" {
   scope_id                    = "global"
   name                        = "worker 2"
   description                 = "self managed worker with worker led auth"


### PR DESCRIPTION
The current `boundary_worker` resource example incorrectly references a `boundary_self_managed_worker ` resource that doesn't exist.

This change corrects the resource in the example.

https://registry.terraform.io/providers/hashicorp/boundary/1.1.9/docs/resources/worker
<img width="757" alt="Screenshot 2023-08-22 at 11 32 07 AM" src="https://github.com/hashicorp/terraform-provider-boundary/assets/9087380/0be942e6-34e5-416b-923b-63c4f5319ddb">
