### PR TITLE
chore: fix test workflow for external contributors

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ${{ fromJSON(vars.RUNNER) }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Check workflow files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ${{ fromJSON(vars.RUNNER) }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Determine go version


### PR DESCRIPTION
Just run tests on ubuntu-latest, so they will succeed for external contributors.