### PR TITLE
Update Go & Terraform version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Available in the [Terraform Registry](https://registry.terraform.io/providers/ha
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) >= 0.12.x
--	[Go](https://golang.org/doc/install) >= 1.20
+-	[Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
+-	[Go](https://golang.org/doc/install) >= 1.21
 
 Building The Provider
 ---------------------


### PR DESCRIPTION
Seems Go 1.21> is required to develop the provider: 

```
bouhmad :: ~/terraform-provider-boundary ‹main*› » make testacc                  
TF_ACC=1 go test ./... -v  -timeout 120m
# github.com/hashicorp/terraform-provider-boundary/internal/provider
../go/pkg/mod/github.com/hashicorp/boundary@v0.13.1-0.20231012004550-1ed0a13004b9/internal/event/sink_config.go:9:2: package slices is not in GOROOT (/usr/local/go/src/slices)
note: imported by a module that requires go 1.21
FAIL    github.com/hashicorp/terraform-provider-boundary/internal/provider [setup failed]
?       github.com/hashicorp/terraform-provider-boundary        [no test files]
?       github.com/hashicorp/terraform-provider-boundary/plugins/kms    [no test files]
```

After upgrading go to 1.21, I was able to run make testacc successfully. 
