### PR TITLE
chore: Fix path error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DOCKER_ARGS ?= -d
 PG_OPTS ?=
 TEST_DB_PORT ?= 5432
 BOUNDARY_VERSION = $(shell go mod edit -json | jq -r '.["Require"][] | select(.Path=="github.com/hashicorp/boundary") | .["Version"]')
-GOPATH ?= ~/go
+GOPATH ?= $(abspath ~/go)
 GOMODCACHE ?= $(GOPATH)/pkg/mod
 
 tools:


### PR DESCRIPTION
I was running into the following error when running `make test-database-up`
```
❯ make test-database-up
Using image:                       docker.io/hashicorpboundary/postgres:11-alpine
Additional postgres configuration: 
Using volume:                      ~/go/pkg/mod/github.com/hashicorp/boundary@v0.13.1-0.20231012004550-1ed0a13004b9/internal/db/schema/migrations:/migrations
docker: Error response from daemon: create ~/go/pkg/mod/github.com/hashicorp/boundary@v0.13.1-0.20231012004550-1ed0a13004b9/internal/db/schema/migrations: "~/go/pkg/mod/github.com/hashicorp/boundary@v0.13.1-0.20231012004550-1ed0a13004b9/internal/db/schema/migrations" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
make: *** [test-database-up] Error 125
```

The error seems to point to the formatting of the volume that was passed in. This PR updates the makefile to use an absolute path instead.