### PR TITLE
doc: Fix linter errors

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -26,8 +26,8 @@ data "boundary_user" "org_user" {
 }
 
 data "boundary_scope" "org" {
-  name            = "my-org"
-  parent_scope_id = data.boundary_scope.org.id
+  name     = "my-org"
+  scope_id = data.boundary_scope.org.id
 }
 ```
 

--- a/docs/resources/host_set.md
+++ b/docs/resources/host_set.md
@@ -39,7 +39,6 @@ resource "boundary_host" "first" {
   description     = "My first host!"
   address         = "10.0.0.1"
   host_catalog_id = boundary_host_catalog.static.id
-  scope_id        = boundary_scope.project.id
 }
 
 resource "boundary_host" "second" {
@@ -48,7 +47,6 @@ resource "boundary_host" "second" {
   description     = "My second host!"
   address         = "10.0.0.2"
   host_catalog_id = boundary_host_catalog.static.id
-  scope_id        = boundary_scope.project.id
 }
 
 resource "boundary_host_set" "web" {

--- a/docs/resources/target.md
+++ b/docs/resources/target.md
@@ -61,7 +61,6 @@ resource "boundary_host" "foo" {
   type            = "static"
   name            = "foo"
   host_catalog_id = boundary_host_catalog.foo.id
-  scope_id        = boundary_scope.project.id
   address         = "10.0.0.1"
 }
 
@@ -69,7 +68,6 @@ resource "boundary_host" "bar" {
   type            = "static"
   name            = "bar"
   host_catalog_id = boundary_host_catalog.foo.id
-  scope_id        = boundary_scope.project.id
   address         = "10.0.0.1"
 }
 

--- a/examples/data-sources/boundary_user/data-source.tf
+++ b/examples/data-sources/boundary_user/data-source.tf
@@ -12,6 +12,6 @@ data "boundary_user" "org_user" {
 }
 
 data "boundary_scope" "org" {
-  name            = "my-org"
-  parent_scope_id = data.boundary_scope.org.id
+  name     = "my-org"
+  scope_id = data.boundary_scope.org.id
 }

--- a/examples/resources/boundary_host_set/resource.tf
+++ b/examples/resources/boundary_host_set/resource.tf
@@ -24,7 +24,6 @@ resource "boundary_host" "first" {
   description     = "My first host!"
   address         = "10.0.0.1"
   host_catalog_id = boundary_host_catalog.static.id
-  scope_id        = boundary_scope.project.id
 }
 
 resource "boundary_host" "second" {
@@ -33,7 +32,6 @@ resource "boundary_host" "second" {
   description     = "My second host!"
   address         = "10.0.0.2"
   host_catalog_id = boundary_host_catalog.static.id
-  scope_id        = boundary_scope.project.id
 }
 
 resource "boundary_host_set" "web" {

--- a/examples/resources/boundary_target/resource.tf
+++ b/examples/resources/boundary_target/resource.tf
@@ -46,7 +46,6 @@ resource "boundary_host" "foo" {
   type            = "static"
   name            = "foo"
   host_catalog_id = boundary_host_catalog.foo.id
-  scope_id        = boundary_scope.project.id
   address         = "10.0.0.1"
 }
 
@@ -54,7 +53,6 @@ resource "boundary_host" "bar" {
   type            = "static"
   name            = "bar"
   host_catalog_id = boundary_host_catalog.foo.id
-  scope_id        = boundary_scope.project.id
   address         = "10.0.0.1"
 }
 


### PR DESCRIPTION
This PR addresses some issues in the documentation. 
1. Per https://github.com/hashicorp/terraform-provider-boundary/pull/492, the `boundary_scope` data source uses `scope_id` as a parameter (and not `parent_scope_id`)
2. The `boundary_host` data source does not have `scope_id` as a parameter: https://github.com/hashicorp/terraform-provider-boundary/blob/main/internal/provider/resource_host_static.go#L34