### PR TITLE
test: Fix failure in TestAccCredentialStoreVault

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: "${{ steps.get-go-version.outputs.go-version }}"
+          cache: false
       - name: Determine Go cache paths
         id: go-cache-paths
         run: |

--- a/internal/provider/resource_credential_store_vault_test.go
+++ b/internal/provider/resource_credential_store_vault_test.go
@@ -71,7 +71,6 @@ func tokenHmac(token, accessor string) string {
 }
 
 func TestAccCredentialStoreVault(t *testing.T) {
-	t.Skip("Skipping flakey test until we can figure out why it sometimes fails on CI")
 	tc := controller.NewTestController(t, tcConfig...)
 	defer tc.Shutdown()
 	url := tc.ApiAddrs()[0]
@@ -94,7 +93,7 @@ func TestAccCredentialStoreVault(t *testing.T) {
 		vaultCredStoreName+vaultCredStoreUpdate,
 		vaultCredStoreDesc+vaultCredStoreUpdate,
 		vaultCredStoreNamespace+vaultCredStoreUpdate,
-		"www.updated.com",
+		"localhost",
 		tokenUpdate,
 		false)
 
@@ -132,7 +131,7 @@ func TestAccCredentialStoreVault(t *testing.T) {
 					resource.TestCheckResourceAttr(vaultCredStoreResc, credentialStoreVaultAddressKey, vcUpdate.Addr),
 					resource.TestCheckResourceAttr(vaultCredStoreResc, credentialStoreVaultNamespaceKey, vaultCredStoreNamespace+vaultCredStoreUpdate),
 					resource.TestCheckResourceAttr(vaultCredStoreResc, credentialStoreVaultCaCertKey, string(vcUpdate.CaCert)),
-					resource.TestCheckResourceAttr(vaultCredStoreResc, credentialStoreVaultTlsServerNameKey, "www.updated.com"),
+					resource.TestCheckResourceAttr(vaultCredStoreResc, credentialStoreVaultTlsServerNameKey, "localhost"),
 					resource.TestCheckResourceAttr(vaultCredStoreResc, credentialStoreVaultTlsSkipVerifyKey, "false"),
 					resource.TestCheckResourceAttr(vaultCredStoreResc, credentialStoreVaultTokenKey, tokenUpdate),
 					resource.TestCheckResourceAttr(vaultCredStoreResc, credentialStoreVaultTokenHmacKey, tHmacUpdate),


### PR DESCRIPTION
[ICU-11525](https://hashicorp.atlassian.net/browse/ICU-11525)

Originally, the test `TestAccCredentialStoreVault` was flaky for the following reason

> === RUN   TestAccCredentialStoreVault
>     resource_credential_store_vault_test.go:101: Step 1/8 error: Error running apply: exit status 1
>         Error: error creating credential store: {"kind":"Internal", "message":"credentialstores.(Service).createInRepo: unable to create credential store: vault.(Repository).CreateCredentialStore: unable to lookup vault token: vault.(client).lookupToken: vault: http://localhost:32796: unknown: error #0: Error making API request.\n\nURL: GET http://localhost:32796/v1/auth/token/lookup-self\nCode: 400. Raw Message:\n\nClient sent an HTTP request to an HTTPS server.\n"}
>           with boundary_credential_store_vault.example,
>           on terraform_plugin_test.tf line 44, in resource "boundary_credential_store_vault" "example":
>           44: resource "boundary_credential_store_vault" "example" {


After pulling in `boundary 0.14.3`, which included this fix: https://github.com/hashicorp/boundary/pull/3973, the test started to always fail for the following reason

> resource_credential_store_vault_test.go:101: Step 3/8 error: Error running apply: exit status 1
>         Error: error updating credential store: {"kind":"Internal","message":"credentialstores.(Service).updateInRepo: unable to update credential store: vault.(Repository).UpdateCredentialStore: cannot lookup token for updated store: vault.(client).lookupToken: vault: https://localhost:32800: unknown: error #0: Get \"https://localhost:32800/v1/auth/token/lookup-self\": tls: failed to verify certificate: x509: certificate is valid for localhost, not www.updated.com"}        
>           with boundary_credential_store_vault.example,
>           on terraform_plugin_test.tf line 44, in resource "boundary_credential_store_vault" "example":
>           44: resource "boundary_credential_store_vault" "example" {

So, I think `0.14.3` included a fix for the original flaky behavior, but then exposed an issue with the test (the test server sets up a certificate that's only valid for `localhost`, but we're setting the server name to be `www.updated.com`). 

This PR also includes an adjustment in the GitHub Action to disable caching in the `setup-go` step. We already handle caching in the `Set up Go modules cache` step, and without this adjustment, we were getting duplicate caching, resulting in errors like
```
Error: /usr/bin/tar: ../../../go/pkg/mod/go.mongodb.org/mongo-driver@v1.10.0/version/version.go: Cannot open: File exists
Error: /usr/bin/tar: ../../../go/pkg/mod/go.mongodb.org/mongo-driver@v1.10.0/bson/bsontype/bsontype_test.go: Cannot open: File exists
Error: /usr/bin/tar: ../../../go/pkg/mod/go.mongodb.org/mongo-driver@v1.10.0/bson/bsontype/bsontype.go: Cannot open: File exists
```

[ICU-11525]: https://hashicorp.atlassian.net/browse/ICU-11525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ