### PR TITLE
chore: replace deprecated arguments in provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ Please see our detailed docs for individual resource usage. Below is a complex e
 
 ```hcl
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  auth_method_id                  = "ampw_1234567890"      # changeme
-  password_auth_method_login_name = "myuser"               # changeme
-  password_auth_method_password   = "passpass"             # changeme
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_id         = "ampw_1234567890"      # changeme
+  auth_method_login_name = "myuser"               # changeme
+  auth_method_password   = "passpass"             # changeme
 }
 
 variable "users" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,23 +15,23 @@ Do not keep your authentication password in HCL for production environments, use
 
 ```terraform
 provider "boundary" {
-  addr                   = "http://127.0.0.1:9200"
-  auth_method_id         = "ampw_1234567890" # changeme
-  auth_method_login_name = "myuser"          # changeme
-  auth_method_password   = "passpass"        # changeme
+  addr                            = "http://127.0.0.1:9200"
+  auth_method_id                  = "ampw_1234567890" # changeme
+  password_auth_method_login_name = "myuser"          # changeme
+  password_auth_method_password   = "passpass"        # changeme
 }
 
 provider "boundary" {
-  addr                   = "http://127.0.0.1:9200"
-  auth_method_login_name = "myuser"
-  auth_method_password   = "passpass"
+  addr                            = "http://127.0.0.1:9200"
+  password_auth_method_login_name = "myuser"
+  password_auth_method_password   = "passpass"
 }
 
 provider "boundary" {
-  addr                   = "http://127.0.0.1:9200"
-  auth_method_login_name = "myuser"
-  auth_method_password   = "passpass"
-  scope_id               = "s_1234567890"
+  addr                            = "http://127.0.0.1:9200"
+  password_auth_method_login_name = "myuser"
+  password_auth_method_password   = "passpass"
+  scope_id                        = "s_1234567890"
 }
 ```
 
@@ -54,4 +54,3 @@ provider "boundary" {
 - `scope_id` (String) The scope ID for the default auth method.
 - `tls_insecure` (Boolean) When set to true, does not validate the Boundary API endpoint certificate
 - `token` (String) The Boundary token to use, as a string or path on disk containing just the string. If set, the token read here will be used in place of authenticating with the auth method specified in "auth_method_id", although the recovery KMS mechanism will still override this. Can also be set with the BOUNDARY_TOKEN environment variable.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,3 +54,4 @@ provider "boundary" {
 - `scope_id` (String) The scope ID for the default auth method.
 - `tls_insecure` (Boolean) When set to true, does not validate the Boundary API endpoint certificate
 - `token` (String) The Boundary token to use, as a string or path on disk containing just the string. If set, the token read here will be used in place of authenticating with the auth method specified in "auth_method_id", although the recovery KMS mechanism will still override this. Can also be set with the BOUNDARY_TOKEN environment variable.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,23 +15,23 @@ Do not keep your authentication password in HCL for production environments, use
 
 ```terraform
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  auth_method_id                  = "ampw_1234567890" # changeme
-  password_auth_method_login_name = "myuser"          # changeme
-  password_auth_method_password   = "passpass"        # changeme
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_id         = "ampw_1234567890" # changeme
+  auth_method_login_name = "myuser"          # changeme
+  auth_method_password   = "passpass"        # changeme
 }
 
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  password_auth_method_login_name = "myuser"
-  password_auth_method_password   = "passpass"
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_login_name = "myuser"
+  auth_method_password   = "passpass"
 }
 
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  password_auth_method_login_name = "myuser"
-  password_auth_method_password   = "passpass"
-  scope_id                        = "s_1234567890"
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_login_name = "myuser"
+  auth_method_password   = "passpass"
+  scope_id               = "s_1234567890"
 }
 ```
 
@@ -54,3 +54,4 @@ provider "boundary" {
 - `scope_id` (String) The scope ID for the default auth method.
 - `tls_insecure` (Boolean) When set to true, does not validate the Boundary API endpoint certificate
 - `token` (String) The Boundary token to use, as a string or path on disk containing just the string. If set, the token read here will be used in place of authenticating with the auth method specified in "auth_method_id", although the recovery KMS mechanism will still override this. Can also be set with the BOUNDARY_TOKEN environment variable.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,23 +15,23 @@ Do not keep your authentication password in HCL for production environments, use
 
 ```terraform
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  auth_method_id                  = "ampw_1234567890" # changeme
-  password_auth_method_login_name = "myuser"          # changeme
-  password_auth_method_password   = "passpass"        # changeme
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_id         = "ampw_1234567890" # changeme
+  auth_method_login_name = "myuser"          # changeme
+  auth_method_password   = "passpass"        # changeme
 }
 
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  password_auth_method_login_name = "myuser"
-  password_auth_method_password   = "passpass"
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_login_name = "myuser"
+  auth_method_password   = "passpass"
 }
 
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  password_auth_method_login_name = "myuser"
-  password_auth_method_password   = "passpass"
-  scope_id                        = "s_1234567890"
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_login_name = "myuser"
+  auth_method_password   = "passpass"
+  scope_id               = "s_1234567890"
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,4 +54,3 @@ provider "boundary" {
 - `scope_id` (String) The scope ID for the default auth method.
 - `tls_insecure` (Boolean) When set to true, does not validate the Boundary API endpoint certificate
 - `token` (String) The Boundary token to use, as a string or path on disk containing just the string. If set, the token read here will be used in place of authenticating with the auth method specified in "auth_method_id", although the recovery KMS mechanism will still override this. Can also be set with the BOUNDARY_TOKEN environment variable.
-

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,19 +1,19 @@
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  auth_method_id                  = "ampw_1234567890" # changeme
-  password_auth_method_login_name = "myuser"          # changeme
-  password_auth_method_password   = "passpass"        # changeme
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_id         = "ampw_1234567890" # changeme
+  auth_method_login_name = "myuser"          # changeme
+  auth_method_password   = "passpass"        # changeme
 }
 
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  password_auth_method_login_name = "myuser"
-  password_auth_method_password   = "passpass"
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_login_name = "myuser"
+  auth_method_password   = "passpass"
 }
 
 provider "boundary" {
-  addr                            = "http://127.0.0.1:9200"
-  password_auth_method_login_name = "myuser"
-  password_auth_method_password   = "passpass"
-  scope_id                        = "s_1234567890"
+  addr                   = "http://127.0.0.1:9200"
+  auth_method_login_name = "myuser"
+  auth_method_password   = "passpass"
+  scope_id               = "s_1234567890"
 }


### PR DESCRIPTION
The `password_auth_method_login_name` and `password_auth_method_password` arguments are deprecated in favor of `auth_method_login_name` and `auth_method_password`.