### PR TITLE
Add Data Source Check For Resource

### DIFF
--- a/scripts/generate_data_sources.go
+++ b/scripts/generate_data_sources.go
@@ -246,6 +246,7 @@ func NewResourceFromSwagger(swagger *spec.Swagger, root, path string) (*Resource
 		parts[i] = cases.Title(language.English, cases.Compact).String(part)
 	}
 	resourceName := strings.Join(parts, "")
+	log.Printf("Resource name: %s", resourceName)
 
 	// Find the field that is used to list the items for this resource. This
 	// is done by finding a parameter that is a also a field in the items list
@@ -686,4 +687,19 @@ func write(data string, filename string) error {
 
 	f.Write([]byte(data))
 	return nil
+}
+
+// Check if terraform resource exists
+func resourceExists(resourceFilePath string) bool {
+	// Assuming the resource files are in the internal/provider directory
+	if _, err := os.Stat(resourceFilePath); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func getResourceFileFromPath(path string) string {
+	resourceFilePath := fmt.Sprintf("../internal/provider/resource_%s.go", resourceName)
+
+	return resourceFilePath
 }


### PR DESCRIPTION
# Overview
The goal of this smaller PR is to assert that only data sources should be generated if there is a matching resource for the boundary terraform provider that already exists. This facilitates us to make so that data sources such as `auth-tokens` and `sessions` are not generated, as likely that are not useful to provider a data reference to. 

# Changes 
- Add a method to determine based on the resource paths from the openapi json, if an associated resource of the same type already exists within the provider, if not then skip generating that data source. 

## Notes
Because not all data sources map perfectly 1-1 with resources, in order to determine if a resource *likely exists globbing is performed in order to check if a resource for the provider exists. An example of this would be data source `host_catalog` vs the resource `boundary_host_catalog_static`. 

