### PR TITLE
chore: Update use of deprecated `hub` command

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -22,7 +22,7 @@ jobs:
       id: boundary-team-role
       run: |
         TEAM="boundary"
-        ROLE="$(hub api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
+        ROLE="$(gh api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
         if [[ -n "${ROLE}" ]]; then
           echo "Actor ${{ github.actor }} is a ${TEAM} team member, skipping ticket creation"
         else


### PR DESCRIPTION
This PR updates the use of `hub` in the `jira.yml` workflow. The command is no longer available by default, and the suggestion is to update to use the `gh` command. It would cause this step of the workflow to constantly fail, which would create a JIRA ticket for every PR opened, even if the user was internal.

Example:
```
/home/runner/work/_temp/7e8d2cb7-1460-4712-ae87-25df58ee7218.sh: line 2: hub: command not found
Actor moduli is not a boundary team member
```

I also needed to update the `JIRA_SYNC_GITHUB_TOKEN` secret with a new token (borrowing the same one used in `boundary-ui`)

A similar change was applied in the boundary-ui repo in this PR: https://github.com/hashicorp/boundary-ui/pull/1729/files