### PR TITLE
adds rdp example, updates outdated resource example types

### DIFF
--- a/docs/resources/target.md
+++ b/docs/resources/target.md
@@ -50,35 +50,30 @@ resource "boundary_credential_library_vault" "foo" {
   credential_type     = "username_password"
 }
 
-resource "boundary_host_catalog" "foo" {
+resource "boundary_host_catalog_static" "foo" {
   name        = "test"
   description = "test catalog"
   scope_id    = boundary_scope.project.id
-  type        = "static"
 }
 
-resource "boundary_host" "foo" {
-  type            = "static"
+resource "boundary_host_static" "foo" {
   name            = "foo"
-  host_catalog_id = boundary_host_catalog.foo.id
+  host_catalog_id = boundary_host_catalog_static.foo.id
   address         = "10.0.0.1"
 }
 
-resource "boundary_host" "bar" {
-  type            = "static"
+resource "boundary_host_static" "bar" {
   name            = "bar"
-  host_catalog_id = boundary_host_catalog.foo.id
+  host_catalog_id = boundary_host_catalog_static.foo.id
   address         = "10.0.0.1"
 }
 
-resource "boundary_host_set" "foo" {
-  type            = "static"
+resource "boundary_host_set_static" "foo" {
   name            = "foo"
-  host_catalog_id = boundary_host_catalog.foo.id
-
+  host_catalog_id = boundary_host_catalog_static.foo.id
   host_ids = [
-    boundary_host.foo.id,
-    boundary_host.bar.id,
+    boundary_host_static.foo.id,
+    boundary_host_static.bar.id,
   ]
 }
 
@@ -93,7 +88,7 @@ resource "boundary_storage_bucket" "aws_example" {
     "access_key_id"     = "aws_access_key_id_value",
     "secret_access_key" = "aws_secret_access_key_value"
   })
-  worker_filter = "\"pki\" in \"/tags/type\""
+  egress_worker_filter = "\"pki\" in \"/tags/type\""
 }
 
 resource "boundary_target" "foo" {
@@ -103,7 +98,7 @@ resource "boundary_target" "foo" {
   default_port = "22"
   scope_id     = boundary_scope.project.id
   host_source_ids = [
-    boundary_host_set.foo.id
+    boundary_host_set_static.foo.id
   ]
   brokered_credential_source_ids = [
     boundary_credential_library_vault.foo.id
@@ -112,12 +107,12 @@ resource "boundary_target" "foo" {
 
 resource "boundary_target" "ssh_foo" {
   name         = "ssh_foo"
-  description  = "Ssh target"
+  description  = "SSH target"
   type         = "ssh"
   default_port = "22"
   scope_id     = boundary_scope.project.id
   host_source_ids = [
-    boundary_host_set.foo.id
+    boundary_host_set_static.foo.id
   ]
   injected_application_credential_source_ids = [
     boundary_credential_library_vault.foo.id
@@ -126,18 +121,33 @@ resource "boundary_target" "ssh_foo" {
 
 resource "boundary_target" "ssh_session_recording_foo" {
   name         = "ssh_foo"
-  description  = "Ssh target"
+  description  = "SSH target"
   type         = "ssh"
   default_port = "22"
   scope_id     = boundary_scope.project.id
   host_source_ids = [
-    boundary_host_set.foo.id
+    boundary_host_set_static.foo.id
   ]
   injected_application_credential_source_ids = [
     boundary_credential_library_vault.foo.id
   ]
   enable_session_recording = true
   storage_bucket_id        = boundary_storage_bucket.aws_example
+}
+
+resource "boundary_target" "rdp_foo" {
+  name         = "rdp_foo"
+  description  = "RDP target"
+  type         = "rdp"
+  default_port = "3389"
+  scope_id     = boundary_scope.project.id
+  host_source_ids = [
+    boundary_host_set_static.foo.id
+  ]
+  injected_application_credential_source_ids = [
+    boundary_credential_library_vault.foo.id
+  ]
+  egress_worker_filter     = "\"egress\" in \"/tags/type\""
 }
 
 resource "boundary_target" "address_foo" {


### PR DESCRIPTION
## Description

This PR updates the `boundary_target` resource examples to include an RDP target.

It also fixes the examples the use outdated resource names, such as `boundary_host_catalog` to `boundary_host_catalog_static`.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.