### PR TITLE
feat: Allow worker filter to be parsed by vault credential store to a…

### DIFF
--- a/internal/provider/resource_credential_store_vault.go
+++ b/internal/provider/resource_credential_store_vault.go
@@ -36,6 +36,7 @@ var storeVaultAttrs = []string{
 	credentialStoreVaultTlsServerNameKey,
 	credentialStoreVaultTlsSkipVerifyKey,
 	credentialStoreVaultClientCertificateKey,
+	credentialStoreVaultWorkerFilterKey,
 }
 
 func resourceCredentialStoreVault() *schema.Resource {
@@ -141,9 +142,6 @@ func setFromVaultCredentialStoreResponseMap(d *schema.ResourceData, raw map[stri
 		return diag.FromErr(err)
 	}
 	if err := d.Set(ScopeIdKey, raw[ScopeIdKey]); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set(credentialStoreVaultWorkerFilterKey, raw[credentialStoreVaultWorkerFilterKey]); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_credential_store_vault_test.go
+++ b/internal/provider/resource_credential_store_vault_test.go
@@ -70,6 +70,37 @@ func tokenHmac(token, accessor string) string {
 	return base64.RawURLEncoding.EncodeToString(hmac)
 }
 
+func TestSetFromVaultCredentialStoreResponseMapReadsWorkerFilterFromAttributes(t *testing.T) {
+	data := schema.TestResourceDataRaw(t, resourceCredentialStoreVault().Schema, map[string]interface{}{})
+
+	raw := map[string]interface{}{
+		"id":           "cs_1234567890",
+		NameKey:        vaultCredStoreName,
+		DescriptionKey: vaultCredStoreDesc,
+		ScopeIdKey:     "p_1234567890",
+		"attributes": map[string]interface{}{
+			credentialStoreVaultAddressKey:                  "https://vault.example.com",
+			credentialStoreVaultNamespaceKey:                vaultCredStoreNamespace,
+			credentialStoreVaultCaCertKey:                   "ca-cert",
+			credentialStoreVaultTlsServerNameKey:            "vault.example.com",
+			credentialStoreVaultTlsSkipVerifyKey:            false,
+			credentialStoreVaultClientCertificateKey:        "client-cert",
+			credentialStoreVaultWorkerFilterKey:             "\"prod\" in \"/tags/env\"",
+			credentialStoreVaultTokenHmacKey:                "token-hmac",
+			credentialStoreVaultClientCertificateKeyHmacKey: "client-key-hmac",
+		},
+	}
+
+	diags := setFromVaultCredentialStoreResponseMap(data, raw, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", diags)
+	}
+
+	if got := data.Get(credentialStoreVaultWorkerFilterKey); got != raw["attributes"].(map[string]interface{})[credentialStoreVaultWorkerFilterKey] {
+		t.Fatalf("worker_filter mismatch: got %v want %v", got, raw["attributes"].(map[string]interface{})[credentialStoreVaultWorkerFilterKey])
+	}
+}
+
 func TestAccCredentialStoreVault(t *testing.T) {
 	tc := controller.NewTestController(t, tcConfig...)
 	defer tc.Shutdown()


### PR DESCRIPTION
Parse the worker filter in the vault credential store to avoid drift. 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.