### PR TITLE
docs: Update preferred endpoints definition

### DIFF
--- a/docs/resources/host_set_plugin.md
+++ b/docs/resources/host_set_plugin.md
@@ -57,7 +57,10 @@ resource "boundary_host_set_plugin" "web" {
 resource "boundary_host_set_plugin" "foobar" {
   name                = "My foobar host set plugin"
   host_catalog_id     = boundary_host_catalog_plugin.aws_example.id
-  preferred_endpoints = ["cidr:54.0.0.0/8"]
+  preferred_endpoints = [
+    "cidr:54.0.0.0/8",
+    "dns:*.internal"
+  ]
   attributes_json = jsonencode({
     "filters" = ["tag-key=foo", "tag-key=bar"]
   })

--- a/docs/resources/host_set_plugin.md
+++ b/docs/resources/host_set_plugin.md
@@ -128,7 +128,7 @@ resource "boundary_host_set_plugin" "foodev" {
 - `attributes_json` (String) The attributes for the host set. Either values encoded with the "jsonencode" function, pre-escaped JSON string, or a file:// or env:// path. Set to a string "null" or remove the block to clear all attributes in the host set.
 - `description` (String) The host set description.
 - `name` (String) The host set name. Defaults to the resource name.
-- `preferred_endpoints` (List of String) The ordered list of preferred endpoints.
+- `preferred_endpoints` (List of String) The ordered list of preferred endpoints. Specifies which IP address or DNS name is your preferred endpoint for when Boundary establishes a session with a target. CIDR strings should follow the `cidr:<valid IPv4/6 CIDR>` format, for example, `cidr:10.0.0.0/16`. DNS strings should follow the `dns:<globbed name>` format, for example `dns:*.internal`.
 - `sync_interval_seconds` (Number) The value to set for the sync interval seconds.
 - `type` (String) The type of host set
 


### PR DESCRIPTION
From a feature request [FRB-191](https://hashicorp.atlassian.net/browse/FRB-191) for updated documentation on the preferred_endpoint attribute. This PR updates the field definition with additional info and adds a DNS endpoint to the example code.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

[FRB-191]: https://hashicorp.atlassian.net/browse/FRB-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ