### PR TITLE
Fix accidental nested loop

### DIFF
--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -151,18 +151,15 @@ func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	if grantStringsVal, ok := d.GetOk(roleGrantStringsKey); ok {
 		list := grantStringsVal.(*schema.Set).List()
 		grantStrings = make([]string, 0, len(list))
-		for _, i := range list {
-			for _, grant := range list {
-				deprecationNotice, err := checkGrantForDeprecation(grant.(string))
-				if err != nil {
-					return diag.FromErr(err)
-				}
-				if deprecationNotice != "" {
-					diags = append(diags, diag.Diagnostic{Severity: diag.Warning, Summary: "deprecated field found in grant", Detail: deprecationNotice})
-				}
-				grantStrings = append(grantStrings, grant.(string))
+		for _, grant := range list {
+			deprecationNotice, err := checkGrantForDeprecation(grant.(string))
+			if err != nil {
+				return diag.FromErr(err)
 			}
-			grantStrings = append(grantStrings, i.(string))
+			if deprecationNotice != "" {
+				diags = append(diags, diag.Diagnostic{Severity: diag.Warning, Summary: "deprecated field found in grant", Detail: deprecationNotice})
+			}
+			grantStrings = append(grantStrings, grant.(string))
 		}
 	}
 
@@ -174,6 +171,9 @@ func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	if tcr == nil {
 		return diag.Errorf("nil role after create")
+	}
+	if tcr.Item == nil {
+		return diag.Errorf("nil role item after create")
 	}
 	apiResponse := tcr.GetResponse().Map
 	defer func() {


### PR DESCRIPTION
Minor fixes  
1) resourceRoleCreate had an accidental nested loop that iterated the same list twice
2) Added a missing nil check

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.