### PR TITLE
chore: Update changelog for 1.5.x changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Canonical reference for changes, improvements, and bugfixes for the Boundary Ter
 
 ## Next
 
+## 1.5.1 (Feb 2nd, 2026)
+
+### New and Improved
+
+* Adds support for Vault LDAP Credential Store.
+  ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/778))
+
+## 1.5.0 (December 19th, 2025)
+
+### New and Improved
+
+* Adds support for Password credentials.
+  ([PR](https://github.com/hashicorp/terraform-provider-boundary/pull/758))
+
 ## 1.4.0 (September 25th, 2025)
 
 ### New and Improved


### PR DESCRIPTION
## Overview
Updates the `CHANGELOG` in `main` to included the denoted changes present in both `main` and `release/1.5.x` 