### PR TITLE
feat(target): Support session recording and storage buckets for RDP targets

### DIFF
--- a/docs/resources/target.md
+++ b/docs/resources/target.md
@@ -176,14 +176,14 @@ resource "boundary_target" "address_foo" {
 - `default_port` (Number) The default port for this target.
 - `description` (String) The target description.
 - `egress_worker_filter` (String) Boolean expression to filter the workers used to access this target
-- `enable_session_recording` (Boolean) HCP/Ent Only. Enable sessions recording for this target. Only applicable for SSH targets.
+- `enable_session_recording` (Boolean) HCP/Ent Only. Enable sessions recording for this target. Only applicable for SSH and RDP targets.
 - `host_source_ids` (Set of String) A list of host source ID's. Cannot be used alongside address.
 - `ingress_worker_filter` (String) HCP Only. Boolean expression to filter the workers a user will connect to when initiating a session against this target
 - `injected_application_credential_source_ids` (Set of String) A list of injected application credential source ID's.
 - `name` (String) The target name. Defaults to the resource name.
 - `session_connection_limit` (Number)
 - `session_max_seconds` (Number)
-- `storage_bucket_id` (String) HCP/Ent Only. Storage bucket for this target. Only applicable for SSH targets.
+- `storage_bucket_id` (String) HCP/Ent Only. Storage bucket for this target. Only applicable for SSH and RDP targets.
 - `worker_filter` (String, Deprecated) Boolean expression to filter the workers for this target
 
 ### Read-Only

--- a/internal/provider/resource_target.go
+++ b/internal/provider/resource_target.go
@@ -137,12 +137,12 @@ func resourceTarget() *schema.Resource {
 				ConflictsWith: []string{targetHostSourceIdsKey},
 			},
 			targetEnableSessionRecordingKey: {
-				Description: "HCP/Ent Only. Enable sessions recording for this target. Only applicable for SSH targets.",
+				Description: "HCP/Ent Only. Enable sessions recording for this target. Only applicable for SSH and RDP targets.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
 			targetStorageBucketIdKey: {
-				Description: "HCP/Ent Only. Storage bucket for this target. Only applicable for SSH targets.",
+				Description: "HCP/Ent Only. Storage bucket for this target. Only applicable for SSH and RDP targets.",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
@@ -210,8 +210,8 @@ func setFromTargetResponseMap(d *schema.ResourceData, raw map[string]interface{}
 				}
 			}
 
-			// SSH only features
-			if typeStr == targetTypeSsh {
+			// Session recording features (SSH and RDP)
+			if typeStr == targetTypeSsh || typeStr == targetTypeRdp {
 				if sessionRecordingVal, ok := attrs[targetEnableSessionRecordingKey].(bool); ok {
 					if err := d.Set(targetEnableSessionRecordingKey, sessionRecordingVal); err != nil {
 						return err
@@ -303,6 +303,8 @@ func resourceTargetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		switch typeStr {
 		case targetTypeSsh:
 			opts = append(opts, targets.WithSshTargetEnableSessionRecording(enableSessionRecordingBool))
+		case targetTypeRdp:
+			opts = append(opts, targets.WithRdpTargetEnableSessionRecording(enableSessionRecordingBool))
 		}
 	}
 
@@ -312,6 +314,8 @@ func resourceTargetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		switch typeStr {
 		case targetTypeSsh:
 			opts = append(opts, targets.WithSshTargetStorageBucketId(storageBucketIdStr))
+		case targetTypeRdp:
+			opts = append(opts, targets.WithRdpTargetStorageBucketId(storageBucketIdStr))
 		}
 	}
 
@@ -505,6 +509,14 @@ func resourceTargetUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				enableSessionRecording = &enableSessionRecordingBool
 				opts = append(opts, targets.WithSshTargetEnableSessionRecording(enableSessionRecordingBool))
 			}
+		case targetTypeRdp:
+			opts = append(opts, targets.WithRdpTargetEnableSessionRecording(false))
+			enableSessionRecordingVal, ok := d.GetOk(targetEnableSessionRecordingKey)
+			if ok {
+				enableSessionRecordingBool := enableSessionRecordingVal.(bool)
+				enableSessionRecording = &enableSessionRecordingBool
+				opts = append(opts, targets.WithRdpTargetEnableSessionRecording(enableSessionRecordingBool))
+			}
 		}
 	}
 
@@ -518,6 +530,14 @@ func resourceTargetUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				storageBucketStr := storageBucketVal.(string)
 				storageBucket = &storageBucketStr
 				opts = append(opts, targets.WithSshTargetStorageBucketId(storageBucketStr))
+			}
+		case targetTypeRdp:
+			opts = append(opts, targets.DefaultRdpTargetStorageBucketId())
+			storageBucketVal, ok := d.GetOk(targetStorageBucketIdKey)
+			if ok {
+				storageBucketStr := storageBucketVal.(string)
+				storageBucket = &storageBucketStr
+				opts = append(opts, targets.WithRdpTargetStorageBucketId(storageBucketStr))
 			}
 		}
 	}


### PR DESCRIPTION
## Overview
This PR extends session recording and storage bucket support to RDP targets in the Boundary provider. Previously these features only worked for SSH targets. Now users can enable session recording and attach a storage bucket to RDP targets through the same `enable_session_recording` and `storage_bucket_id` attributes. 