### PR TITLE
chore: supress openpgp vulnerability

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -11,4 +11,18 @@ binary {
   osv          = true
   oss_index    = false
   nvd          = false
+
+    triage {
+    suppress {
+      vulnerabilities = [
+        // golang.org/x/crypto/openpgp is deprecated/unmaintained with no fixed
+        // version. The provider does not use this package (confirmed via
+        // `go mod why golang.org/x/crypto/openpgp`); it imports the maintained
+        // fork github.com/ProtonMail/go-crypto/openpgp instead. x/crypto is
+        // only pulled in for the unaffected golang.org/x/crypto/cryptobyte
+        // package. Not reachable in the built binary.
+        "GO-2026-5932",
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Description
This PR suppresses the following vulnerability

```
Scanned file:{path:"to-scan.imHC/terraform-provider-boundary_v1.6.0_x5"} in 45.3s - found 1 result(s)
  » Go Modules Scanner
    ⚠︎ found OSV reported vulnerability GO-2026-5932 in golang.org/x/crypto@v0.54.0
        to-scan.imHC/terraform-provider-boundary_v1.6.0_x5:1:1
```
This is due to golang.org/x/crypto/openpgp being unmaintained.

Looks like we are not using that.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.