### PR TITLE
Set default build github workflow permissions to read-only

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,8 @@ on: [workflow_dispatch, push]
 env:
   PKG_NAME: "terraform-provider-boundary"
 
+permissions: read-all
+
 jobs:
   # Detects the Go version to use for builds.
   get-go-version:


### PR DESCRIPTION
Set GITHUB_TOKEN to read-only permission by default within build workflow.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.